### PR TITLE
PORT should be changed as WEBSITES_PORT in Application settings

### DIFF
--- a/java/spring-framework/deploy-spring-boot-java-app-on-linux.md
+++ b/java/spring-framework/deploy-spring-boot-java-app-on-linux.md
@@ -218,7 +218,7 @@ When the deployment is complete, click **Go to resource**.  The deployment page 
 >
 > 4. Click **Configuration** in the left navigation pane.
 >
-> 5. In the **Application settings** section, add a new setting named **PORT** and enter your custom port number for the value.
+> 5. In the **Application settings** section, add a new setting named **WEBSITES_PORT** and enter your custom port number for the value.
 >
 > 6. Click **OK**. Then click **Save**.
 >


### PR DESCRIPTION
Under 'Diagnose and solve problems' -> 'Availability and Performance' -> 'Application Logs ' section in App Services, it clearly states that the application settings for port change should be mentioned under setting named - 'WEBSITES_PORT' and not 'PORT'.
Please review.