### PR TITLE
Automatic request mapping do not happen for port 8080

### DIFF
--- a/java/spring-framework/deploy-spring-boot-java-app-on-linux.md
+++ b/java/spring-framework/deploy-spring-boot-java-app-on-linux.md
@@ -210,7 +210,7 @@ When the deployment is complete, click **Go to resource**.  The deployment page 
 
 > [!NOTE]
 >
-> Azure will automatically map Internet requests to embedded Tomcat server that is running on the standard ports of 80 or 8080. However, if you configured your embedded Tomcat server to run on a custom port, you need to add an environment variable to your web app that defines the port for your embedded Tomcat server. To do so, use the following steps:
+> Azure will automatically map Internet requests to embedded Tomcat server that is running on the port - 80. However, if you configured your embedded Tomcat server to run on port - 8080 or custom port, you need to add an environment variable to your web app that defines the port for your embedded Tomcat server. To do so, use the following steps:
 >
 > 1. Browse to the [Azure portal] and sign in.
 > 


### PR DESCRIPTION
On the note section in the following link - https://docs.microsoft.com/en-us/azure/java/spring-framework/deploy-spring-boot-java-app-on-linux#create-a-web-app-on-linux-on-azure-app-service-using-your-container-image , it is stated that "Azure will automatically map Internet requests to embedded Tomcat server that is running on the standard ports of 80 or 8080. "

But this seems to be not working. The automatic mapping happens for just port 80 and for 8080, the mapping needs to be configured in Application settings using WEBSITES_PORT setting.

Closes #80