### PR TITLE
Fix ClassNotFoundError -> ClassNotFoundException

### DIFF
--- a/java/jdk/transition-from-java-8-to-java-11.md
+++ b/java/jdk/transition-from-java-8-to-java-11.md
@@ -385,7 +385,7 @@ This issue can be resolved by using `--patch-module <module-name>=<path>[,<path>
 ##### NoClassDefFoundError caused by using Java EE or CORBA modules
 
 If the application runs on Java 8 but throws a `java.lang.NoClassDefFoundError` or a 
-`java.lang.ClassNotFoundError`, then it is
+`java.lang.ClassNotFoundException`, then it is
 likely that the application is using a package from the Java EE or CORBA modules. 
 These modules were deprecated in Java 9 and [removed in Java 11](https://openjdk.java.net/jeps/320). 
 


### PR DESCRIPTION
`java.lang.ClassNotFoundError` does not seem to exist. I believe that the correct one is the `java.lang.ClassNotFoundException`, which is usually the cause for the mentioned `java.lang.NoClassDefFoundError`.