### PR TITLE
Correcting az browse command to use az webapp

### DIFF
--- a/articles/python/azure-sdk-get-started.yml
+++ b/articles/python/azure-sdk-get-started.yml
@@ -255,7 +255,7 @@ items:
 
     Open a browser pointed to the application using the CLI:
     ```azurecli
-    az appservice web browse --resource-group sampleWebResourceGroup --name YOUR_APP_NAME
+    az webapp browse --resource-group sampleWebResourceGroup --name YOUR_APP_NAME
     ```
 
     Remove the web app and plan from your subscription once you've verified the deployment. 


### PR DESCRIPTION
The web command is no longer in the az appservice command group. The update mechanism to do is to install the az webapp extension and then use az webapp browse command to view the webapp in the browser