### PR TITLE
Update create-vm-scaleset-network-disks-using-packer-hcl.md

### DIFF
--- a/articles/terraform/create-vm-scaleset-network-disks-using-packer-hcl.md
+++ b/articles/terraform/create-vm-scaleset-network-disks-using-packer-hcl.md
@@ -114,7 +114,7 @@ resource "azurerm_public_ip" "vmss" {
   name                         = "vmss-public-ip"
   location                     = var.location
   resource_group_name          = azurerm_resource_group.vmss.name
-  allocation_method            = "static"
+  allocation_method            = "Static"
   domain_name_label            = azurerm_resource_group.vmss.name
 
   tags {
@@ -345,7 +345,7 @@ resource "azurerm_public_ip" "jumpbox" {
   name                         = "jumpbox-public-ip"
   location                     = var.location
   resource_group_name          = azurerm_resource_group.vmss.name
-  allocation_method            = "static"
+  allocation_method            = "Static"
   domain_name_label            = "${azurerm_resource_group.vmss.name}-ssh"
 
   tags {


### PR DESCRIPTION
With current way there is a problem with Naming of the allocation_method value. So I capitalised it  and it works as excepted.

```
 Error: expected allocation_method to be one of [Static Dynamic], got static
   on jumpbox.tf line 1, in resource "azurerm_public_ip" "jumpbox":
    1: resource "azurerm_public_ip" "jumpbox" {
 Error: expected allocation_method to be one of [Static Dynamic], got static
   on vmss.tf line 28, in resource "azurerm_public_ip" "vmss":
   28: resource "azurerm_public_ip" "vmss" {
```