### PR TITLE
Support Roadmap updated based on the Azure

### DIFF
--- a/articles/java/fundamentals/java-jdk-long-term-support.md
+++ b/articles/java/fundamentals/java-jdk-long-term-support.md
@@ -6,9 +6,12 @@ ms.topic: conceptual
 ms.custom: seo-java-september2019
 ---
 
-# Java long-term support for Azure and Azure Stack
+# Java long-term support and and medium-term support for Azure and Azure Stack
 
 Java developers on Azure and Azure Stack can build and run production Java applications using the [Azul Zulu for Azure - Enterprise Edition](https://www.azul.com/downloads/azure-only/zulu/) JDK builds without incurring additional support costs. You can use any Java runtime you want on Azure, but when you use Zulu you get free maintenance updates and can create support issues with Microsoft.
+
+A release designated as LTS(Long Term Support) are those same LTS releases as designed by Oracle and the OpenJDK community. For LTS releases, we provides at least 8 years of access to bug fixes, security updates, and other (“Production Support”) fixes as needed plus 2 years of additional support intended to advise and assist users to migrate to a newer JDK version (“Extended Support”).
+For those releases designed as MTS, we provides Production Support for at least 1.5 years after the general availability of the next LTS release, plus an additional 1 year of Extended Support.
 
 > [!div class="nextstepaction"]
 > [Download and install Java](java-jdk-install.md)
@@ -19,7 +22,7 @@ Java developers on Azure and Azure Stack can build and run production Java appli
 * [Java 8](https://www.azul.com/downloads/azure-only/zulu/?&version=java-8-lts)
 * [Java 7](https://www.azul.com/downloads/azure-only/zulu/?&version=java-7-lts)
 
-## Technical preview
+## Medium Term Support (MTS) 
 
 * [Java 13](https://www.azul.com/downloads/azure-only/zulu/?&version=java-13)
 
@@ -48,9 +51,9 @@ Azul Systems provides fully-supported [Azul Zulu for Azure - Enterprise Edition]
 |Java SE LTS  |Support until  |
 |---------|----------|
 |[![Supported Java version - Java 7](media/supported-java-versions-java-7.png)](https://www.azul.com/downloads/azure-only/zulu/?&version=java-7-lts) |July 2023 |
-|[![Supported Java version - Java 8](media/supported-java-versions-java-8.png)](https://www.azul.com/downloads/azure-only/zulu/?&version=java-8-lts) |March 2025|
-|[![Supported Java version - Java 11](media/supported-java-versions-java-11.png)](https://www.azul.com/downloads/azure-only/zulu/?&version=java-11-lts) |Sept. 2026|
-|[![Supported Java version - Java 13](media/supported-java-versions-java-13.png)](https://www.azul.com/downloads/azure-only/zulu/?&version=java-13) |**PREVIEW**|
+|[![Supported Java version - Java 8](media/supported-java-versions-java-8.png)](https://www.azul.com/downloads/azure-only/zulu/?&version=java-8-lts) |Dec 2030|
+|[![Supported Java version - Java 11](media/supported-java-versions-java-11.png)](https://www.azul.com/downloads/azure-only/zulu/?&version=java-11-lts) |Sept 2027|
+|[![Supported Java version - Java 13](media/supported-java-versions-java-13.png)](https://www.azul.com/downloads/azure-only/zulu/?&version=java-13) |Mar 2023|
 
 These JDK releases have quarterly security updates, bug fixes, and critical out-of-band updates and patches as needed.  This support includes back ports of security updates and bug fixes to Java 7 and 8 reported in newer versions of Java such as Java 11, which ensures the continued stability and security of older versions of Java.  Azure customers can get these security updates and platform bug fixes without incurring any unplanned Java SE subscription fees.
 
@@ -64,7 +67,7 @@ The Azul Zulu for Azure - Enterprise Edition JDK releases are:
 
    * Zulu binaries are production-ready and backed by Microsoft and Azul Systems
    * Zulu comes with zero-cost long-term support (LTS) for Java 7, 8, and 11. (LTS will be provided for Java 17, as well). You can upgrade Java versions only when you need to.
-   * Java 7 supported until July 2023. Java 8 and 11 are supported beyond 2024.
+   * Java 7 supported until July 2023. Java 8 and 11 are supported beyond 2027.
    * Microsoft is committed to running Zulu internally on machines that power many Azure services.
 
 2. Production-ready
@@ -110,7 +113,7 @@ The Azul Zulu for Azure - Enterprise Edition JDK releases are:
 4. No cost
 
    * Microsoft provides everything you need to build and scale Java apps on Azure at no cost to you. Through Zulu you'll receive free security updates and platform bug fixes for Java apps without any fees.
-   * [Java Flight Recorder and Mission Control](java-jdk-flight-recorder-and-mission-control.md) are available in Zulu Java 8, 11, and 12 (Preview).
+   * [Java Flight Recorder and Mission Control](java-jdk-flight-recorder-and-mission-control.md) are available in Zulu Java 8, 11, and later.
 
 5. Tech Preview of Non-LTS versions
 


### PR DESCRIPTION
The EoL support roadmap was update on Azul.
And this is good news for some Java users.

Based on the Azul update, we also need to update the page too.
https://www.azul.com/products/azul-support-roadmap/

And already Java 13 is published officially and no more preview, so I modified the Java 13 related contents too.