### PR TITLE
Update create-linux-virtual-machine-with-infrastructure.md

### DIFF
--- a/articles/terraform/create-linux-virtual-machine-with-infrastructure.md
+++ b/articles/terraform/create-linux-virtual-machine-with-infrastructure.md
@@ -78,7 +78,7 @@ resource "azurerm_subnet" "myterraformsubnet" {
     name                 = "mySubnet"
     resource_group_name  = azurerm_resource_group.myterraformgroup.name
     virtual_network_name = azurerm_virtual_network.myterraformnetwork.name
-    address_prefix       = "10.0.2.0/24"
+    address_prefixes       = ["10.0.2.0/24"]
 }
 ```
 
@@ -282,7 +282,7 @@ resource "azurerm_subnet" "myterraformsubnet" {
     name                 = "mySubnet"
     resource_group_name  = azurerm_resource_group.myterraformgroup.name
     virtual_network_name = azurerm_virtual_network.myterraformnetwork.name
-    address_prefix       = "10.0.1.0/24"
+    address_prefixes       = ["10.0.1.0/24"]
 }
 
 # Create public IPs
@@ -463,7 +463,7 @@ terraform apply
 Once Terraform completes, your VM infrastructure is ready. Obtain the public IP address of your VM with [az vm show](/cli/azure/vm):
 
 ```azurecli-interactive
-az vm show --resource-group myResourceGroup --name myVM -d --query [publicIps] --o tsv
+az vm show --resource-group myResourceGroup --name myVM -d --query [publicIps] --output tsv
 ```
 
 You can then SSH to your VM:


### PR DESCRIPTION
Minor fixes
:81 and 285 Warning: "address_prefix": [DEPRECATED] Use the `address_prefixes` property instead.
:466 - az: error: ambiguous option: --o could match --only-show-errors, --output