### PR TITLE
Update azure_rm.py links to community.general URI

### DIFF
--- a/articles/ansible/dynamic-inventory-configure.md
+++ b/articles/ansible/dynamic-inventory-configure.md
@@ -82,12 +82,12 @@ Once you have your virtual machines defined (and tagged), it's time to generate 
 
 ### Using Ansible version < 2.8
 
-Ansible provides a Python script named [azure_rm.py](https://github.com/ansible/ansible/blob/stable-2.9/contrib/inventory/azure_rm.py) that generates a dynamic inventory of your Azure resources. The following steps walk you through using the `azure_rm.py` script to connect to your two test Azure virtual machines:
+Ansible provides a Python script named [azure_rm.py](https://github.com/ansible-collections/community.general/blob/master/scripts/inventory/azure_rm.py) that generates a dynamic inventory of your Azure resources. The following steps walk you through using the `azure_rm.py` script to connect to your two test Azure virtual machines:
 
 1. Use the GNU `wget` command to retrieve the `azure_rm.py` script:
 
     ```python
-    wget https://raw.githubusercontent.com/ansible/ansible/devel/contrib/inventory/azure_rm.py
+    wget https://raw.githubusercontent.com/ansible-collections/community.general/master/scripts/inventory/azure_rm.py
     ```
 
 1. Use the `chmod` command to change the access permissions to the `azure_rm.py` script. The following command uses the `+x` parameter to allow for execution (running) of the specified file (`azure_rm.py`):


### PR DESCRIPTION
The Azure dynamic inventory script was [moved](https://github.com/ansible/ansible/commit/4e488d8435b3b3458de08bb2e4532bfbe6318121) from ansible/ansible to [ansible-collections/community.general](https://github.com/ansible-collections/community.general/blob/master/scripts/inventory/azure_rm.py) and the URIs in this tutorial need to be updated.