### PR TITLE
Remove semicolon from python tutorial-vs-code-serverless-python-06

### DIFF
--- a/articles/python/tutorial-vs-code-serverless-python-06.md
+++ b/articles/python/tutorial-vs-code-serverless-python-06.md
@@ -48,7 +48,7 @@ After your first deployment, you can make changes to your code, such as adding a
             output += "%04d" % (carry + (total / scale))
             carry = total % scale
 
-        return output;
+        return output
 
     def main(req: func.HttpRequest) -> func.HttpResponse:
         logging.info('DigitsOfPi HTTP trigger function processed a request.')


### PR DESCRIPTION
I noticed an extra semicolon when going through step 6 of the "Create and deploy serverless Azure Functions in Python with Visual Studio Code." This fix just removes that extra semicolon in the tutorial so that other users don't experience that in the future. 