### PR TITLE
Change web app to Java app

### DIFF
--- a/articles/java/quickstarts/index.yml
+++ b/articles/java/quickstarts/index.yml
@@ -9,7 +9,7 @@ metadata:
   ms.date: 04/08/2020
 
 landingContent:
-  - title: Deploy web apps
+  - title: Deploy Java apps
     linkLists:
       - linkListType: quickstart
         links:


### PR DESCRIPTION
Changing it to Java apps open up a broader range of Java-based applications, such as web server, app servers, pojo, API, etc. Java stack usually includes more than just the web-tier. 