### PR TITLE
Changes "+" for "Initialize Repository"

### DIFF
--- a/articles/javascript/tutorial-vscode-azure-app-service-node-03.md
+++ b/articles/javascript/tutorial-vscode-azure-app-service-node-03.md
@@ -18,7 +18,7 @@ In this step, you deploy your Node.js app to Azure using Git deploy through the 
     code .
     ```
 
-1. In VS Code, select the source control icon to open the **Source Control** explorer, then select **+** to initialize a local Git repository:
+1. In VS Code, select the source control icon to open the **Source Control** explorer, then select **Initialize Repository** to initialize a local Git repository:
 
     ![Initialize git repository](media/deploy-azure/git-init.png)
 


### PR DESCRIPTION
The button for initializing a repository was referred to as "+". There are no plus signs there.