### PR TITLE
Added provider block

### DIFF
--- a/articles/terraform/store-state-in-azure-storage.md
+++ b/articles/terraform/store-state-in-azure-storage.md
@@ -91,6 +91,10 @@ terraform {
   }
 }
 
+provider "azurerm" {
+   features {}
+}
+
 resource "azurerm_resource_group" "state-demo-secure" {
   name     = "state-demo"
   location = "eastus"


### PR DESCRIPTION
The azurerm provider version is not listed and the 2.0 provider requires the features block

Without this block (or perhaps a version) the tutorial gives an error

![image](https://user-images.githubusercontent.com/23503973/98274580-3532bc80-1f59-11eb-8d36-691552580637.png)


Found the resolution here
https://stackoverflow.com/questions/60384689/terraform-azurerm-2-x-error-features-required-field-is-not-set