### PR TITLE
Update link to Terrascan in Terraform integration test tutorial

### DIFF
--- a/articles/terraform/best-practices-integration-testing.md
+++ b/articles/terraform/best-practices-integration-testing.md
@@ -94,7 +94,7 @@ Static code analysis can be done directly on the Terraform configuration code, w
 The following tools provide static analysis for Terraform files:
 
 - [Checkov](https://github.com/bridgecrewio/checkov/)
-- [Terrascan](https://github.com/cesar-rodriguez/terrascan)
+- [Terrascan](https://github.com/accurics/terrascan)
 - [tfsec](https://github.com/liamg/tfsec) 
 - [Deepsource](https://deepsource.io/blog/release-terraform-static-analysis/) 
 


### PR DESCRIPTION
Update the repository link pointing to Terrascan from the old repository
to the new one in the Terraform integration test tutorial.

Resolves #356