### PR TITLE
Update link to tfsec in Terraform integration test tutorial

### DIFF
--- a/articles/terraform/best-practices-integration-testing.md
+++ b/articles/terraform/best-practices-integration-testing.md
@@ -95,7 +95,7 @@ The following tools provide static analysis for Terraform files:
 
 - [Checkov](https://github.com/bridgecrewio/checkov/)
 - [Terrascan](https://github.com/cesar-rodriguez/terrascan)
-- [tfsec](https://github.com/liamg/tfsec) 
+- [tfsec](https://github.com/tfsec/tfsec)
 - [Deepsource](https://deepsource.io/blog/release-terraform-static-analysis/) 
 
 Static analysis is often executed part of a continuous integration pipeline. These tests don't require the creation of an execution plan or deployment. As a result, they run faster than other tests and are generally run first in the continuous integration process.


### PR DESCRIPTION
Update the repository link pointing to tfsec from the old repository to
the new one in the Terraform integration test tutorial.

Resolves #358