### PR TITLE
Update tutorial-vscode-docker-node-02.md

### DIFF
--- a/articles/javascript/tutorial-vscode-docker-node-02.md
+++ b/articles/javascript/tutorial-vscode-docker-node-02.md
@@ -16,7 +16,7 @@ This tutorial uses [Azure Container Registry](https://azure.microsoft.com/servic
 
 ## Create an Azure container registry
 
-1. In Visual Studio Code, select **F1** to open the command palette.
+1. In Visual Studio Code, select **F1** or **CTRL+SHIFT+P** to open the command palette.
 
 1. Enter **registry** in the search box. From the results, select **Azure Container Registry: Create Registry**.
 


### PR DESCRIPTION
There is a conflict with the mappings on particular laptops or desktops. To open the Command Palette, for some  **F1** works but for some only **CTRL+SHIFT+P** works. This PR is to add the other option of using **CTRL+SHIFT+P**, just in case one **F1** didn't work.