### PR TITLE
Fix provider warning in base Terraform sample

### DIFF
--- a/articles/terraform/includes/terraform-create-base-config-file.md
+++ b/articles/terraform/includes/terraform-create-base-config-file.md
@@ -13,8 +13,16 @@ ms.author: tarcher
 A Terraform configuration file starts off with the specification of the provider. When using Azure, you'll specify the [Azure provider (azurerm)](https://www.terraform.io/docs/providers/azurerm/index.html) in the `provider` block.
 
 ```terraform
+terraform {
+  required_providers {
+    azurerm = {
+      source = "hashicorp/azurerm"
+      version = "~>2.0"
+    }
+  }
+}
+
 provider "azurerm" {
-  version = "~>2.0"
   features {}
 }
 


### PR DESCRIPTION
Using the base tf file sample, terraform init gives out the following warning:
```
Warning: Version constraints inside provider configuration blocks are deprecated

   2:     version = "~>2.0"

Terraform 0.13 and earlier allowed provider version constraints inside the
provider configuration block, but that is now deprecated and will be removed
in a future version of Terraform. To silence this warning, move the provider
version constraint into the required_providers block.
```
The proposed fix removes the warning.