### PR TITLE
Fix typo in notification-hubs-backend-service-configure-xamarin-ios.md

### DIFF
--- a/articles/mobile-apps/includes/notification-hubs-backend-service-configure-xamarin-ios.md
+++ b/articles/mobile-apps/includes/notification-hubs-backend-service-configure-xamarin-ios.md
@@ -60,7 +60,7 @@
                 if (!NotificationsSupported)
                     throw new Exception(GetNotificationsSupportError());
 
-                if (string.isNullOrWhitespace(Token))
+                if (string.IsNullOrWhitespace(Token))
                     throw new Exception("Unable to resolve token for APNS");
 
                 var installation = new DeviceInstallation


### PR DESCRIPTION
Typo in C# code. `isNullOrWhitespace` needs a capital "I".