### PR TITLE
Fix typo in notification-hubs-backend-service-configure-xamarin-android.md

### DIFF
--- a/articles/mobile-apps/includes/notification-hubs-backend-service-configure-xamarin-android.md
+++ b/articles/mobile-apps/includes/notification-hubs-backend-service-configure-xamarin-android.md
@@ -75,7 +75,7 @@
                 if (!NotificationsSupported)
                     throw new Exception(GetPlayServicesError());
 
-                if (string.isNullOrWhitespace(Token))
+                if (string.IsNullOrWhitespace(Token))
                     throw new Exception("Unable to resolve token for FCM");
 
                 var installation = new DeviceInstallation


### PR DESCRIPTION
Typo in C# code. `isNullOrWhitespace` needs a capital "I".