### PR TITLE
add interim step to remove bug with diff tf vers

### DIFF
--- a/articles/terraform/best-practices-compliance-testing.md
+++ b/articles/terraform/best-practices-compliance-testing.md
@@ -138,6 +138,12 @@ In this section, you'll download and test the example.
     terraform plan -out tf.out
     ```
     
+1. Run [terraform show](https://www.terraform.io/docs/commands/show.html) to convert the execution plan to json for the compliance step.
+
+    ```bash
+    terraform show -json tf.out > tf.out.json
+    ```
+
 1. Run [terraform apply](https://www.terraform.io/docs/commands/apply.html) to apply the execution plan.
 
     ```bash
@@ -153,7 +159,7 @@ In this section, you'll download and test the example.
 1. Run [docker run](https://docs.docker.com/engine/reference/commandline/run/) to run the tests in a docker container. **The test will fail**. The first rule requiring existence of tags succeeds. However, the second rule fails in that the `Role` and `Creator` tags are missing.
 
     ```bash
-    docker run --rm -v $PWD:/target -it eerkunt/terraform-compliance -f features -p tf.out
+    docker run --rm -v $PWD:/target -it eerkunt/terraform-compliance -f features -p tf.out.json
     ```
     
     ![Example of a failed test](media/best-practices-compliance-testing/best-practices-compliance-testing-tagging-fail.png)
@@ -181,11 +187,17 @@ In this section, you'll download and test the example.
     ```bash
     terraform plan -out tf.out
     ```
+
+1. Run [terraform show](https://www.terraform.io/docs/commands/show.html) to convert the execution plan to json for the compliance step.
+
+    ```bash
+    terraform show -json tf.out > tf.out.json
+    ```
     
 1. Run [docker run](https://docs.docker.com/engine/reference/commandline/run/) again to test the configuration. This time, the test succeeds as the full spec has been implemented.
 
     ```bash
-    docker run --rm -v $PWD:/target -it eerkunt/terraform-compliance -f features -p tf.out
+    docker run --rm -v $PWD:/target -it eerkunt/terraform-compliance -f features -p tf.out.json
     ```
 
     ![Example of a successful test](media/best-practices-compliance-testing/best-practices-compliance-testing-tagging-succeed.png)


### PR DESCRIPTION
The docker terraform-compliance image packages in it terraform binaries for a specific version (for example image eerkunt/terraform-compliance:1.3.8 has terraform 0.14.0). However when terraform plan is used with a different version (for example 0.13.0), it throws an error: https://github.com/terraform-compliance/cli/issues/273, https://github.com/terraform-compliance/cli/issues/381 . I.e. a user running the commands in this document is likely to get an error unless they are running the version of terraform in the image. 
There are two ways of addressing this known to me:
1. Add the terraform binaries for the version 'terraform plan' is using the --terraform flag in the terraform-compliance command https://github.com/terraform-compliance/cli/issues/381
2. Add an intermediate step to convert the execution plan to json and then just supply that file as seen here https://github.com/terraform-compliance/cli/issues/381

This pull request provides the second option as it removes the need to transfer terraform binaries to a docker image. 