### PR TITLE
Added the 'depends_on' Meta-Argument for kubesubnet and appgwsubnet

### DIFF
--- a/articles/terraform/create-k8s-cluster-with-aks-applicationgateway-ingress.md
+++ b/articles/terraform/create-k8s-cluster-with-aks-applicationgateway-ingress.md
@@ -299,12 +299,14 @@ Create Terraform configuration file that creates all the resources.
       name                 = var.aks_subnet_name
       virtual_network_name = azurerm_virtual_network.test.name
       resource_group_name  = data.azurerm_resource_group.rg.name
+      depends_on = [azurerm_virtual_network.test]
     }
 
     data "azurerm_subnet" "appgwsubnet" {
       name                 = "appgwsubnet"
       virtual_network_name = azurerm_virtual_network.test.name
       resource_group_name  = data.azurerm_resource_group.rg.name
+      depends_on = [azurerm_virtual_network.test]
     }
 
     # Public Ip 


### PR DESCRIPTION
Added the 'depends_on' Meta-Argument for azurerm_subnet.kubesubnet and azurerm_subnet.appgwsubnet. This is done to prevent the below error:

Error: Subnet "kubesubnet" was not found
Error: Subnet "appgwsubnet" was not found 

The depends_on Meta-Argument will ensure that the VNet and both the subnets are created first and then the information is read.