### PR TITLE
Typo "Azure blob storage"→"Azure Blob Storage"

### DIFF
--- a/articles/javascript/tutorial/browser-file-upload-azure-storage-blob.md
+++ b/articles/javascript/tutorial/browser-file-upload-azure-storage-blob.md
@@ -187,7 +187,7 @@ If you received an error or your file doesn't upload to the container, check the
 
 The `src/App.tsx` TypeScript file is provided as part of that app creation with create-react-app. The file has been modified to provide the file selection button and the upload button and the supporting code to provide that functionality. 
 
-The code connecting to the Azure blob storage code is highlighted. The call to `uploadFileToBlob` returns all blobs (files) in the container as a flat list. That list is displayed with the `DisplayImagesFromContainer` function.
+The code connecting to the Azure Blob Storage code is highlighted. The call to `uploadFileToBlob` returns all blobs (files) in the container as a flat list. That list is displayed with the `DisplayImagesFromContainer` function.
 
 :::code language="typescript" source="~/../js-e2e-browser-file-upload-storage-blob/src/App.tsx" highlight="3,28":::
 


### PR DESCRIPTION
https://docs.microsoft.com/en-us/azure/developer/javascript/tutorial/browser-file-upload-azure-storage-blob