### PR TITLE
Remove download link to Ansible VSCode extension

### DIFF
--- a/articles/ansible/index.yml
+++ b/articles/ansible/index.yml
@@ -42,10 +42,7 @@ landingContent:
         links:
           - text: Configure a dynamic inventory
             url: dynamic-inventory-configure.md
-      - linkListType: download
-        links:
-          - text: Visual Studio Code extension for Ansible
-            url: https://marketplace.visualstudio.com/items?itemName=vscoss.vscode-ansible
+
   # Card
   - title: Manage Virtual Machines
     linkLists:

--- a/articles/ansible/toc.yml
+++ b/articles/ansible/toc.yml
@@ -110,7 +110,3 @@
     href: module-version-matrix.md
   - name: All modules for Azure
     href: https://docs.ansible.com/ansible/2.9/modules/list_of_cloud_modules.html#azure
-- name: Resources
-  items:
-  - name: Visual Studio Code extension for Ansible
-    href: https://marketplace.visualstudio.com/items?itemName=vscoss.vscode-ansible


### PR DESCRIPTION
These download links go to an extension that's been abandoned.
![image](https://user-images.githubusercontent.com/4173978/106962175-90f51900-66f3-11eb-986e-2ffe5b693479.png)

Alternative extensions available are not maintained by Microsoft.