### PR TITLE
Fix errors in sample code: Incorrect `credential_scopes` is passed to SDK clients

### DIFF
--- a/articles/python/azure-sdk-sovereign-domain.md
+++ b/articles/python/azure-sdk-sovereign-domain.md
@@ -23,28 +23,32 @@ Pre-defined sovereign cloud constants are provided by the `azure_cloud` module o
 
 To use a definition, import the appropriate constant from `msrestazure.azure_cloud` and apply it when creating client objects. 
 
-When using `DefaultAzureCredential`, as shown in the following example, you also need to use the appropriate value from `azure.identity.AzureAuthorityHosts`.
+When using `DefaultAzureCredential`, as shown in the following example, you also need to use the appropriate value from `CLOUD.endpoints.active_directory`.
 
 ```python
 import os
-from msrestazure.azure_cloud import AZURE_CHINA_CLOUD as cloud
+from msrestazure.azure_cloud import AZURE_CHINA_CLOUD as CLOUD
 from azure.mgmt.resource import ResourceManagementClient, SubscriptionClient
 from azure.identity import DefaultAzureCredential
 
-# Assumes the subscription ID to use is in the AZURE_SUBSCRIPTION_ID environment variable
+# Assumes the subscription ID and tenant ID to use are in the AZURE_SUBSCRIPTION_ID,
+# AZURE_TENANT_ID environment variables
 subscription_id = os.environ["AZURE_SUBSCRIPTION_ID"]
+tenant_id = os.environ["AZURE_TENANT_ID"]
 
 # When using sovereign domains (that is, any cloud other than AZURE_PUBLIC_CLOUD),
 # you must use an authority with DefaultAzureCredential.
-credential = DefaultAzureCredential(authority=cloud.endpoints.active_directory)
+credential = DefaultAzureCredential(authority=CLOUD.endpoints.active_directory, tenant_id=tenant_id)
 
-resource_client = ResourceManagementClient(credential,
-    subscription_id, base_url=cloud.endpoints.resource_manager,
-    credential_scopes=[cloud.endpoints.resource_manager + ".default'"])
+resource_client = ResourceManagementClient(
+    credential, subscription_id,
+    base_url=CLOUD.endpoints.resource_manager,
+    credential_scopes=[CLOUD.endpoints.resource_manager + "/.default"])
 
-subscription_client = SubscriptionClient(credential,
-    base_url=stack_cloud.endpoints.resource_manager,
-    credential_scopes=[cloud.endpoints.resource_manager + ".default'"])
+subscription_client = SubscriptionClient(
+    credential,
+    base_url=CLOUD.endpoints.resource_manager,
+    credential_scopes=[CLOUD.endpoints.resource_manager + "/.default"])
 ```
   
 ## Using your own cloud definition
@@ -67,11 +71,13 @@ stack_cloud = get_cloud_from_metadata_endpoint("https://contoso-azurestack-arm-e
 # https:// is optional in the URL but required on the endpoint.
 credential = DefaultAzureCredential(authority=stack_cloud.endpoints.active_directory)
 
-resource_client = ResourceManagementClient(credential, subscription_id,
+resource_client = ResourceManagementClient(
+    credential, subscription_id,
     base_url=stack_cloud.endpoints.resource_manager,
-    credential_scopes=[cloud.endpoints.resource_manager + ".default'"])
+    credential_scopes=[cloud.endpoints.active_directory_resource_id + "/.default"])
 
-subscription_client = SubscriptionClient(credential,
+subscription_client = SubscriptionClient(
+    credential,
     base_url=stack_cloud.endpoints.resource_manager,
-    credential_scopes=[stack_cloud.endpoints.resource_manager + ".default'"])
+    credential_scopes=[stack_cloud.endpoints.active_directory_resource_id + "/.default"])
 ```

--- a/articles/python/azure-sdk-sovereign-domain.md
+++ b/articles/python/azure-sdk-sovereign-domain.md
@@ -60,6 +60,7 @@ import os
 from msrestazure.azure_cloud import get_cloud_from_metadata_endpoint
 from azure.mgmt.resource import ResourceManagementClient, SubscriptionClient
 from azure.identity import DefaultAzureCredential
+from azure.profiles import KnownProfiles
 
 # Assumes the subscription ID and tenant ID to use are in the AZURE_SUBSCRIPTION_ID,
 # AZURE_TENANT_ID environment variables

--- a/articles/python/azure-sdk-sovereign-domain.md
+++ b/articles/python/azure-sdk-sovereign-domain.md
@@ -61,23 +61,26 @@ from msrestazure.azure_cloud import get_cloud_from_metadata_endpoint
 from azure.mgmt.resource import ResourceManagementClient, SubscriptionClient
 from azure.identity import DefaultAzureCredential
 
-# Assumes the subscription ID to use is in the AZURE_SUBSCRIPTION_ID environment variable
+# Assumes the subscription ID and tenant ID to use are in the AZURE_SUBSCRIPTION_ID,
+# AZURE_TENANT_ID environment variables
 subscription_id = os.environ["AZURE_SUBSCRIPTION_ID"]
+tenant_id = os.environ["AZURE_TENANT_ID"]
 
 stack_cloud = get_cloud_from_metadata_endpoint("https://contoso-azurestack-arm-endpoint.com")
 
-# When using a private, you must use an authority with DefaultAzureCredential.
+# When using a private cloud, you must use an authority with DefaultAzureCredential.
 # The active_directory endpoint should be a URL like https://login.microsoftonline.com.
-# https:// is optional in the URL but required on the endpoint.
-credential = DefaultAzureCredential(authority=stack_cloud.endpoints.active_directory)
+credential = DefaultAzureCredential(authority=stack_cloud.endpoints.active_directory, tenant_id=tenant_id)
 
 resource_client = ResourceManagementClient(
     credential, subscription_id,
     base_url=stack_cloud.endpoints.resource_manager,
+    profile=KnownProfiles.v2019_03_01_hybrid,
     credential_scopes=[stack_cloud.endpoints.active_directory_resource_id + "/.default"])
 
 subscription_client = SubscriptionClient(
     credential,
     base_url=stack_cloud.endpoints.resource_manager,
+    profile=KnownProfiles.v2019_03_01_hybrid,
     credential_scopes=[stack_cloud.endpoints.active_directory_resource_id + "/.default"])
 ```

--- a/articles/python/azure-sdk-sovereign-domain.md
+++ b/articles/python/azure-sdk-sovereign-domain.md
@@ -31,7 +31,7 @@ from msrestazure.azure_cloud import AZURE_CHINA_CLOUD as CLOUD
 from azure.mgmt.resource import ResourceManagementClient, SubscriptionClient
 from azure.identity import DefaultAzureCredential
 
-# Assumes the subscription ID and tenant ID to use are in the AZURE_SUBSCRIPTION_ID,
+# Assumes the subscription ID and tenant ID to use are in the AZURE_SUBSCRIPTION_ID and
 # AZURE_TENANT_ID environment variables
 subscription_id = os.environ["AZURE_SUBSCRIPTION_ID"]
 tenant_id = os.environ["AZURE_TENANT_ID"]
@@ -62,7 +62,7 @@ from azure.mgmt.resource import ResourceManagementClient, SubscriptionClient
 from azure.identity import DefaultAzureCredential
 from azure.profiles import KnownProfiles
 
-# Assumes the subscription ID and tenant ID to use are in the AZURE_SUBSCRIPTION_ID,
+# Assumes the subscription ID and tenant ID to use are in the AZURE_SUBSCRIPTION_ID and
 # AZURE_TENANT_ID environment variables
 subscription_id = os.environ["AZURE_SUBSCRIPTION_ID"]
 tenant_id = os.environ["AZURE_TENANT_ID"]

--- a/articles/python/azure-sdk-sovereign-domain.md
+++ b/articles/python/azure-sdk-sovereign-domain.md
@@ -74,7 +74,7 @@ credential = DefaultAzureCredential(authority=stack_cloud.endpoints.active_direc
 resource_client = ResourceManagementClient(
     credential, subscription_id,
     base_url=stack_cloud.endpoints.resource_manager,
-    credential_scopes=[cloud.endpoints.active_directory_resource_id + "/.default"])
+    credential_scopes=[stack_cloud.endpoints.active_directory_resource_id + "/.default"])
 
 subscription_client = SubscriptionClient(
     credential,


### PR DESCRIPTION
Fix https://github.com/Azure/azure-cli/issues/16696: Incorrect `credential_scopes` is passed to SDK clients.

This PR fixes errors in https://docs.microsoft.com/en-us/azure/developer/python/azure-sdk-sovereign-domain