### PR TITLE
Revert "Typo "Azure container instances"→"Azure Container Instances""

### DIFF
--- a/articles/ansible/application-gateway-configure.md
+++ b/articles/ansible/application-gateway-configure.md
@@ -18,8 +18,8 @@ ms.custom: devx-track-ansible
 > [!div class="checklist"]
 >
 > * Set up a network
-> * Create two Azure Container Instances with HTTPD images
-> * Create an application gateway that works with the Azure Container Instances in the server pool
+> * Create two Azure container instances with HTTPD images
+> * Create an application gateway that works with the Azure container instances in the server pool
 
 ## Prerequisites
 
@@ -110,7 +110,7 @@ ansible-playbook vnet_create.yml
 
 ## Create servers
 
-The playbook code in this section creates two Azure Container Instances with HTTPD images to be used as web servers for the application gateway.  
+The playbook code in this section creates two Azure container instances with HTTPD images to be used as web servers for the application gateway.  
 
 Save the following playbook as `aci_create.yml`:
 


### PR DESCRIPTION
Reverts MicrosoftDocs/azure-dev-docs#501

I'm reverting this as the brand (Azure service name) is Azure Container Instances. Therefore, when referring to the service, it should be called Azure Container Instances (capitalized). However, in the context given (that the PR creator wants to change), it's not the brand being referenced; it's an instance. Therefore, it's correct being lowercase. Note https://docs.microsoft.com/en-us/azure/container-instances/container-instances-overview where the term is capitalized only when referring to the service.