### PR TITLE
Removed double of "allowing"

### DIFF
--- a/articles/includes/choose-the-right-azure-command-line-tool.md
+++ b/articles/includes/choose-the-right-azure-command-line-tool.md
@@ -58,7 +58,7 @@ Azure CLI has an installer that makes its commands executable in all four shell 
 
 Azure PowerShell is set of cmdlets packaged as a PowerShell module named `Az`; not an executable. Windows PowerShell or PowerShell must be used to install the `Az` module. 
 
-Windows PowerShell is the standard scripting shell that comes preinstalled with most Windows operating systems. PowerShell is a stand-alone installation that uses .NET Core as it's run time, allowing allowing it to be installed on macOS, Linux, and Windows.
+Windows PowerShell is the standard scripting shell that comes preinstalled with most Windows operating systems. PowerShell is a stand-alone installation that uses .NET Core as it's run time, allowing it to be installed on macOS, Linux, and Windows.
 
 **Key points:**
 


### PR DESCRIPTION
Removed the duplicate of "allowing" in 
"...that uses .NET Core as it's run time, allowing **allowing** it to be installed on macOS, Linux, and Windows."