### PR TITLE
Update connect-from-azure.md

### DIFF
--- a/articles/github/connect-from-azure.md
+++ b/articles/github/connect-from-azure.md
@@ -27,7 +27,7 @@ You can use Azure login to connect to public or sovereign clouds including Azure
 
 To set up an Azure Login with OpenID Connect and use it in a GitHub Actions workflow, you'll need:
 
-* An [Active Directory application](/azure/active-directory/develop/), with a service principal that has contributor access to your subscription
+* An [Active Directory application](/azure/active-directory/develop/), with a service principal that has contributor access to your resourece
 * An Active Directory application configured with a federated credential to trust tokens issued by GitHub Actions to your GitHub repository. You can configure this in the Azure portal or with Microsoft Graph REST APIs
 * A GitHub Actions workflow that requests GitHub issue tokens to the workflow, and uses the `azure/login@v1.4.0` action
 

--- a/articles/github/connect-from-azure.md
+++ b/articles/github/connect-from-azure.md
@@ -27,7 +27,7 @@ You can use Azure login to connect to public or sovereign clouds including Azure
 
 To set up an Azure Login with OpenID Connect and use it in a GitHub Actions workflow, you'll need:
 
-* An [Active Directory application](/azure/active-directory/develop/), with a service principal that has contributor access to your resourece
+* An [Active Directory application](/azure/active-directory/develop/), with a service principal that has contributor access to your resource
 * An Active Directory application configured with a federated credential to trust tokens issued by GitHub Actions to your GitHub repository. You can configure this in the Azure portal or with Microsoft Graph REST APIs
 * A GitHub Actions workflow that requests GitHub issue tokens to the workflow, and uses the `azure/login@v1.4.0` action
 


### PR DESCRIPTION
The service principal does not need full contributor rights on the subscription itself. Documentation needs to clarify that it's possible to assign contributor rights to the resources (i.e. resource group) for the service principal to perform actions. Ideally we will apply the principle of least privilege when granting permissions.