### PR TITLE
Update tutorial-vscode-azure-cli-node-02.md

### DIFF
--- a/articles/javascript/tutorial/tutorial-vscode-azure-cli-node/tutorial-vscode-azure-cli-node-02.md
+++ b/articles/javascript/tutorial/tutorial-vscode-azure-cli-node/tutorial-vscode-azure-cli-node-02.md
@@ -21,4 +21,4 @@ Clone a GitHub repository with an example Express.js application, install the np
 
 ## Next step
 
-* [Create the app](tutorial-vscode-azure-cli-node-03.md)
+* [Create the app service](tutorial-vscode-azure-cli-node-03.md)


### PR DESCRIPTION
This page of the tutorial had a copy/paste issue from the previous page of tutorial. both have "Create the App" but this one should be "Create the App Service" to match the left pane table of contents