### PR TITLE
Drop Python 2 support

### DIFF
--- a/articles/python/azure-sdk-overview.md
+++ b/articles/python/azure-sdk-overview.md
@@ -14,7 +14,7 @@ The open-source Azure libraries for Python simplify provisioning, managing, and 
 
 - The Azure libraries are how you communicate with Azure services *from* Python code that you run either locally or in the cloud. (Whether you can run Python code within the scope of a particular service depends on whether that service itself currently supports Python.)
 
-- The libraries support Python 2.7 and Python 3.6 or later, and it is also tested with PyPy 5.4+.
+- The libraries support Python 3.7 or later, and it is also tested with PyPy 5.4+.
 
 - The Azure SDK for Python is composed solely of over 180 individual Python libraries that relate to specific Azure services. There are no other tools in the "SDK".
 

--- a/articles/python/azure-sdk-overview.md
+++ b/articles/python/azure-sdk-overview.md
@@ -14,7 +14,7 @@ The open-source Azure libraries for Python simplify provisioning, managing, and 
 
 - The Azure libraries are how you communicate with Azure services *from* Python code that you run either locally or in the cloud. (Whether you can run Python code within the scope of a particular service depends on whether that service itself currently supports Python.)
 
-- The libraries support Python 3.7 or later, and it is also tested with PyPy 5.4+.
+- The libraries support Python 3.6 or later, and it is also tested with PyPy 5.4+.
 
 - The Azure SDK for Python is composed solely of over 180 individual Python libraries that relate to specific Azure services. There are no other tools in the "SDK".
 


### PR DESCRIPTION
As discussed with Azure board and annunced since last September, Python 2 has been stopped on Jan 1st 2022. 
https://github.com/Azure/azure-sdk-for-python/issues/20691