### PR TITLE
Fixed error in yaml that retrieved a VM instead of a RG

### DIFF
--- a/articles/github/connect-from-azure.md
+++ b/articles/github/connect-from-azure.md
@@ -304,8 +304,8 @@ jobs:
       - name: Azure PowerShell Action
         uses: Azure/powershell@v1
         with:
-          inlineScript: Get-AzVM -ResourceGroupName "< YOUR RESOURCE GROUP >"
-          azPSVersion: 3.1.0
+          inlineScript: Get-AzResourceGroup -Name "< YOUR RESOURCE GROUP >"
+          azPSVersion: "latest"
 ```
 
 ### Use the Azure CLI action


### PR DESCRIPTION
Fixed error in yaml that retrieved a VM instead of a RG