### PR TITLE
Incorrect link github-key-vault.md

### DIFF
--- a/articles/github/github-key-vault.md
+++ b/articles/github/github-key-vault.md
@@ -83,7 +83,7 @@ Replace `keyVaultName` with the name of your key vault and `clientIdGUID` with t
 
 ## Add the key vault action
 
-With the [Azure Key Vault action](https://github.com/marketplace/actions/enhanced-env-azure-key-vault-get-secrets), you can fetch one or more secrets from a key vault instance and consume it in your GitHub Action workflows.
+With the [Azure Key Vault action](https://github.com/Azure/get-keyvault-secrets), you can fetch one or more secrets from a key vault instance and consume it in your GitHub Action workflows.
 
 Secrets fetched are set as outputs and also as environment variables. Variables are automatically masked when they are printed to the console or to logs.
 


### PR DESCRIPTION
Hi.

This "broken" link was "fixed" incorrectly a while ago; probably when the GitHub Action it was referencing was deprecated and likely removed from the Marketplace. However, it was replaced by some third-party non-Microsoft `Enhanced ENV Azure Vault Action` that works quite differently.

Instead of pointing to the now missing Marketplace page, I'm updating the link to point to the action's GitHub repo that contains the docs and code.