### PR TITLE
Clarifying assignee object id

### DIFF
--- a/articles/github/connect-from-azure.md
+++ b/articles/github/connect-from-azure.md
@@ -62,7 +62,7 @@ You'll need to create an Azure Active Directory application and service principa
      az ad sp create --id $appId
     ```
 
-1. Create a new role assignment by subscription and object. By default, the role assignment will be tied to your default subscription. Replace `$subscriptionId` with your subscription ID, `$resourceGroupName` with your resource group name, and `$assigneeObjectId` with generated `assignee-object-id`.
+1. Create a new role assignment by subscription and object. By default, the role assignment will be tied to your default subscription. Replace `$subscriptionId` with your subscription ID, `$resourceGroupName` with your resource group name, and `$assigneeObjectId` with generated `assignee-object-id` (the newly created service principal object id).
 
     ```azurecli-interactive
     az role assignment create --role contributor --subscription $subscriptionId --assignee-object-id  $assigneeObjectId --assignee-principal-type ServicePrincipal --scope /subscriptions/$subscriptionId/resourceGroups/$resourceGroupName


### PR DESCRIPTION
Added clarifying text as on can easily confuse the service principal id with the earlier created application "object id"