### PR TITLE
Added limitations sections

### DIFF
--- a/articles/terraform/overview-azapi-provider.md
+++ b/articles/terraform/overview-azapi-provider.md
@@ -151,6 +151,9 @@ AzAPI2AzureRM ensures after migration that your Terraform configuration and stat
     }
     
     ```
+## Limitations
+
+- Since AzAPI is a very thin layer above the Azure ARM REST API, its limitations also apply. As such not all resource types can be deployed to the subscription level. For details about which resources are supported, please visit the following link: https://docs.microsoft.com/en-us/azure/azure-resource-manager/templates/deploy-to-subscription?tabs=azure-cli#supported-resources.
 
 ## Next steps
 


### PR DESCRIPTION
This section is important because we require to make clear for clients that altough there are many cases that can be handled using AzAPI is not a silver bullet, for example registering features at the subscription level is not supported:

```
resource "azapi_update_resource" "encathost" {
  type      = Microsoft.Features/providers@2021-07-01
  name      = "EncryptionAtHost"
  parent_id = data.azurerm_subscription.current.id

  body = jsonencode({
    properties = {
      featureName = "EncryptionAtHost"
      resourceProviderNamespace = "Microsoft.Compute"
      subscriptionId = data.azurerm_subscription.current.id
    }
  })
}
```

This will not work and have to use the following work around:

```
resource "null_resource" "test" {

  provisioner "local-exec" {
    command = "az feature register --namespace Microsoft.Compute --name EncryptionAtHost'"
  }
} 
```

Therefore it is very important to inform clients and users about AzAPI limitations.