### PR TITLE
Added clean up section and fix keyfile permession warning

### DIFF
--- a/articles/terraform/create-linux-virtual-machine-with-infrastructure.md
+++ b/articles/terraform/create-linux-virtual-machine-with-infrastructure.md
@@ -248,7 +248,7 @@ To use SSH to connect to the virtual machine, do the following steps:
 1. Run [terraform output](https://www.terraform.io/cli/commands/output) to get the SSH private key and save it to a file.
 
     ```console
-    terraform output -raw tls_private_key > id_rsa
+    terraform output -raw tls_private_key > ~/id_rsa
     ```
 
 1. Run [terraform output](https://www.terraform.io/cli/commands/output) to get the virtual machine public IP address.
@@ -261,8 +261,14 @@ To use SSH to connect to the virtual machine, do the following steps:
 1. Use SSH to connect to the virtual machine.
 
     ```console
-    ssh -i id_rsa azureuser@<public_ip_address>
+    chmod 600 ~/id_rsa
+    ssh -i ~/id_rsa azureuser@<public_ip_address>
     ```
+
+## Clean up resources
+
+[!INCLUDE [terraform-plan-destroy.md](includes/terraform-plan-destroy.md)]
+
 
 ## Troubleshoot Terraform on Azure
 


### PR DESCRIPTION
This article should have a "clean up" section. We need to tell users how to clean up the 12 objects tf have created.
Also, we need to put the public key to a path to set 600 permission for it. Otherwise, ssh connect will be failed due to a permission warning below.
```
@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
@         WARNING: UNPROTECTED PRIVATE KEY FILE!          @
@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
Permissions 0777 for 'id_rsa' are too open.
It is required that your private key files are NOT accessible by others.
This private key will be ignored.
Load key "id_rsa": bad permissions
```

