### PR TITLE
Corrected the description of Environment Name

### DIFF
--- a/articles/azure-developer-cli/includes/azd-bare-metal.md
+++ b/articles/azure-developer-cli/includes/azd-bare-metal.md
@@ -58,7 +58,7 @@ azd up --template todo-csharp-cosmos-sql
 
 The command prompts for the following information:
 
-- `Environment Name`: Prefix for all your Azure resources, make sure it's globally unique and under 15 characters.
+- `Environment Name`: Prefix for your Azure Resource Group, make sure it's globally unique and under 15 characters.
 - `Azure Location`: The Azure location where your resources will be deployed.
 - `Azure Subscription`: The Azure Subscription where your resources will be deployed.
 

--- a/articles/azure-developer-cli/includes/azd-dev-container.md
+++ b/articles/azure-developer-cli/includes/azd-dev-container.md
@@ -63,7 +63,7 @@ azd init --template todo-csharp-cosmos-sql
 
 You'll be prompted for the following information:
 
-- `Environment Name`: Prefix for all your Azure resources, make sure it's globally unique and under 15 characters.
+- `Environment Name`: Prefix for your Azure Resource Group, make sure it's globally unique and under 15 characters.
 - `Azure Location`: The Azure location where your resources will be deployed.
 - `Azure Subscription`: The Azure Subscription where your resources will be deployed.
 


### PR DESCRIPTION
#837 

The explanation of the Environment Name is described as follows.

>Prefix for all your Azure resources

To be precise, it is a prefix of the resource group and is not used as a prefix of each resource name.