### PR TITLE
docs: navigate to correct page

### DIFF
--- a/articles/azure-developer-cli/overview.md
+++ b/articles/azure-developer-cli/overview.md
@@ -60,7 +60,7 @@ This list is grouped by supported language. Each repository contains a complete 
 
 ## Azure Developer CLI vs Azure CLI
 
-[Azure Developer CLI (azd)](/azure/developer/az-dev-cli) and [Azure CLI](/cli/azure/what-is-azure-cli) are both command-line tools.
+[Azure Developer CLI (azd)](/azure/developer/azure-developer-cli) and [Azure CLI](/cli/azure/what-is-azure-cli) are both command-line tools.
 
 However, they help you do different tasks.
 


### PR DESCRIPTION
The current link goes to a 404 page:

![image](https://user-images.githubusercontent.com/28659384/178659998-4bdf7f1b-1f24-485b-ae16-eb70652ef4ce.png)

The changed link redirects the user to the overview page:

![image](https://user-images.githubusercontent.com/28659384/178660053-c5e4fcae-2577-42cd-aaa6-61362ef209be.png)
