### PR TITLE
Remove the Set-ExecutionPolicy command

### DIFF
--- a/articles/azure-developer-cli/includes/azd-install.md
+++ b/articles/azure-developer-cli/includes/azd-install.md
@@ -7,7 +7,7 @@ Before you get started, ensure you have the following tools installed on your lo
     ### [Windows](#tab/windows)
 
     ```
-    powershell -c "Set-ExecutionPolicy Bypass Process -Force; irm 'https://aka.ms/install-azd.ps1' | iex"
+    powershell -c "irm 'https://aka.ms/install-azd.ps1' | iex"
     ```
 
     ### [Linux/MacOS](#tab/linuxmac)


### PR DESCRIPTION
Remove the Set-ExecutionPolicy command. `irm 'https://aka.ms/install-azd.ps1' | iex` doesn't write anything to disk, so the execution policy doesn't affect it.
Also, if you run `install-azd.ps1` like this in a new PowerShell process, the following code block doesn't make sense, because you won't see that change in the caller's PowerShell session:

```powershell
            # Also add the path to the current session
            $env:PATH += ";$InstallFolder"
```

It only makes sense, if you start Windows PowerShell and run `irm 'https://aka.ms/install-azd.ps1' | iex` directly.