### PR TITLE
Remove a reference to Azul Zulu

### DIFF
--- a/articles/java/spring-framework/configure-spring-boot-starter-java-app-with-azure-key-vault-certificates.md
+++ b/articles/java/spring-framework/configure-spring-boot-starter-java-app-with-azure-key-vault-certificates.md
@@ -128,33 +128,6 @@ Use the following steps to create an Azure VM with a system-assigned managed ide
    sudo apt install msopenjdk-11
    ```
 
-   > [!NOTE]
-   > Another, faster way to get set up the certified Azul Zulu for Azure – Enterprise Edition VM image, which can avoid the installation of Azure SDK. For complete information about Azul Zulu for Azure, see [Download Java for Azure](https://www.azul.com/downloads/azure-only/zulu/).
-   > Run the following command to obtain the URN name.
-   >
-   > ```azurecli
-   >    az vm image list \
-   >        --offer Zulu \
-   >        --location <your region> \
-   >        --all | grep urn
-   > ```
-   >
-   > This command may take a while to complete. When the command completes, it produces output similar to the following lines. Select the value for JDK 11 on Ubuntu.
-   >
-   > ```output
-   > "urn": "azul:azul-zulu11-ubuntu-2004:zulu-jdk11-ubtu2004:20.11.0",
-   > ...
-   > "urn": "azul:azul-zulu8-ubuntu-2004:zulu-jdk8-ubtu2004:20.11.0",
-   > "urn": "azul:azul-zulu8-windows-2019:azul-zulu8-windows2019:20.11.0",
-   > ```
-   >
-   > Use the following command to accept the terms for the image to allow the VM to be created.
-   >
-   > ```azurecli
-   > az vm image terms accept --urn azul:azul-zulu11-ubuntu-2004:zulu-jdk11-ubtu2004:20.11.0
-   > ```
->
-
 ## Create and configure an Azure Key Vault
 
 Use the following steps to create an Azure Key Vault, and to grant permission for the VM's system-assigned managed identity to access the Key Vault for certificates.


### PR DESCRIPTION
Azul Zulu for Azure is EOL see https://www.azul.com/downloads/azure-only/

Other references in the documentation look correct, except https://github.com/MicrosoftDocs/azure-dev-docs/blob/main/articles/jenkins/deploy-to-azure-app-service-using-azure-cli.md#configure-jenkins

I didn't want to conflate the two changes though, so doing this one separately.