### PR TITLE
Wrong version of GH CLI in prerequisites

### DIFF
--- a/articles/azure-developer-cli/includes/azd-install.md
+++ b/articles/azure-developer-cli/includes/azd-install.md
@@ -1,7 +1,7 @@
 Before you get started, ensure you have the following tools installed on your local machine:
 
 - [Git](https://git-scm.com/)
-- [GitHub CLI v2.3+](https://github.com/cli/cli)
+- [GitHub CLI v2.13+](https://github.com/cli/cli)
 - [Azure CLI (v 2.38.0+)](/cli/azure/install-azure-cli)
 - Azure Developer CLI (azd)
     ### [Windows](#tab/windows)


### PR DESCRIPTION
According to the prerequisites the GH CLI should be installed in a version > 2.3. However, the GH CLI most recent version as of today is 2.14.4. I guess this is a typo and corrected it to version 2.13+