### PR TITLE
Typo correction on azure-sdk-authentication.md

### DIFF
--- a/articles/go/azure-sdk-authentication.md
+++ b/articles/go/azure-sdk-authentication.md
@@ -82,7 +82,7 @@ $env:AZURE_CLIENT_SECRET="<service_principal_password>"
 # [Bash](#tab/bash)
 
 ```bash
-export AZURE_TENANT_ID="<active_directory_tenant_id"
+export AZURE_TENANT_ID="<active_directory_tenant_id>"
 export AZURE_CLIENT_ID="<service_principal_appid>"
 export AZURE_CLIENT_CERTIFICATE_PATH="<azure_client_certificate_path>"
 ```
@@ -90,7 +90,7 @@ export AZURE_CLIENT_CERTIFICATE_PATH="<azure_client_certificate_path>"
 # [PowerShell](#tab/powershell)
 
 ```powershell
-$env:AZURE_TENANT_ID="<active_directory_tenant_id"
+$env:AZURE_TENANT_ID="<active_directory_tenant_id>"
 $env:AZURE_CLIENT_ID="<service_principal_appid>"
 $env:AZURE_CLIENT_CERTIFICATE_PATH="<azure_client_certificate_path>"
 ```


### PR DESCRIPTION
Code example `AZURE_TENANT_ID="<active_directory_tenant_id"` under `Service principal with certificate` is missing its closing `>` for both PS & Bash examples

(this is my first contribution to any repo on github that I don't already own, apologies in advance if I've missed something!)