### PR TITLE
Policy Signing Certificate has to be an X.509 Certificate

### DIFF
--- a/articles/terraform/create-attestation-provider.md
+++ b/articles/terraform/create-attestation-provider.md
@@ -32,7 +32,7 @@ In this article, you learn how to:
 
 [!INCLUDE [configure-terraform.md](includes/configure-terraform.md)]
 
-- **Policy Signing Certificate:** A PEM file defines a set of trusted signing keys. As there are many scenarios in which to have a PEM file, this article assumes you have access to one. For example, you can download a PEM during the process of creating a virtual machine in the [Azure portal](https://portal.azure.com).
+- **Policy Signing Certificate:** You need to upload an X.509 certificate, which is used by the attestation provider to validate signed policies. This certificate is either signed by a certificate authority or self-signed. Supported file extensions include pem, txt and cer. This article assumes that you already have a valid X.509 certificate.
 
 ## 2. Implement the Terraform code
 


### PR DESCRIPTION
A PEM file that is obtained when creating a VM does only contain a private key. However, Microsoft Azure Attestation service requires a public key to validate signed policies, which is provided by a signed or self-signed X.509 certificate. If you try to create an attestation provider by using an SSH private key (a PEM file that contains a private key), as suggested in the article, the provisioning fails with this error: "PolicySigningCertificate key is not an X509 security key".

Therefore I suggest these updates to meet the requirements of launching an attestation provider successfully.