### PR TITLE
Switch to openjdk-11 jre to fix Jenkins service

### DIFF
--- a/articles/jenkins/configure-on-linux-vm.md
+++ b/articles/jenkins/configure-on-linux-vm.md
@@ -45,7 +45,7 @@ In this article, you'll learn how to:
     #cloud-config
     package_upgrade: true
     runcmd:
-      - sudo apt install openjdk-8-jdk -y
+      - sudo apt install openjdk-11-jre -y
       - wget -qO - https://pkg.jenkins.io/debian-stable/jenkins.io.key | sudo apt-key add -
       - sh -c 'echo deb https://pkg.jenkins.io/debian-stable binary/ > /etc/apt/sources.list.d/jenkins.list'
       - sudo apt-get update && sudo apt-get install jenkins -y


### PR DESCRIPTION
Jenkins does not run anymore with the openjdk-8. Teh specified package now requires the openjdk-11-jre, so I updated the cloud-init-jenkins.txt file accordingly.