### PR TITLE
Fix links to AVD docs

### DIFF
--- a/articles/terraform/configure-azure-virtual-desktop.md
+++ b/articles/terraform/configure-azure-virtual-desktop.md
@@ -18,9 +18,9 @@ Article tested with the following Terraform and Terraform provider versions:
 
 This article provides an overview of how to use Terraform to deploy an ARM Azure Virtual Desktop environment, not AVD Classic.
 
-There are several pre-requisites [requirements for Azure Virtual Desktop](/azure/virtual-desktop/overview)
+There are several pre-requisites [requirements for Azure Virtual Desktop](/azure/virtual-desktop/prerequisites)
 
-New to Azure Virtual Desktop? Start with [What is Azure Virtual Desktop?](/azure/virtual-desktop/prerequisites)
+New to Azure Virtual Desktop? Start with [What is Azure Virtual Desktop?](/azure/virtual-desktop/overview)
 
 It is assumed that an appropriate platform foundation is already setup which may or may not be the [Enterprise Scale Landing Zone platform foundation.](/azure/cloud-adoption-framework/ready/enterprise-scale/implementation)
 


### PR DESCRIPTION
The links that point to AVD Docs "What is Azure Virtual Desktop" and "Prerequisites" do not match the context of the sentence