### PR TITLE
add step for installing visual studio preview

### DIFF
--- a/articles/azure-developer-cli/includes/debug-visual-studio.md
+++ b/articles/azure-developer-cli/includes/debug-visual-studio.md
@@ -18,13 +18,14 @@ Run and debug apps built on your local machine using [Visual Studio](/visualstud
   
 1. Install [Visual Studio Preview](https://visualstudio.microsoft.com/vs/preview/) 
    
-   Note: this is different from Visual Studio. If you have the non-preview version of Visual Studio, you still need to install this. 
+   > [!NOTE]
+   > This is different from Visual Studio. If you have the non-preview version of Visual Studio, you still need to install this. 
 
-2. Open Visual Studio Preview.
+1. Open Visual Studio Preview.
 
-3. From the **Tools** menu, select **Options** > **Preview Features**.
+1. From the **Tools** menu, select **Options** > **Preview Features**.
 
-4. Make sure **Integration with azd, the Azure Developer CLI** is enabled.
+1. Make sure **Integration with azd, the Azure Developer CLI** is enabled.
 
    :::image type="content" source="../media/debug/visual-studio-options.png" alt-text="Screenshot of the Visual Studio option to turn on integration with the Azure Developer CLI.":::
 

--- a/articles/azure-developer-cli/includes/debug-visual-studio.md
+++ b/articles/azure-developer-cli/includes/debug-visual-studio.md
@@ -13,15 +13,18 @@ Run and debug apps built on your local machine using [Visual Studio](/visualstud
 - [Install azd](../install-azd.md)
 - [Run `azd` with the Node.js template](../get-started.md)
 - [.NET SDK 6.0](https://dotnet.microsoft.com/download/dotnet/6.0)
-- [Visual Studio version later than 17.3.0 Preview 2 with the integration with `azd` feature flag enabled](/visualstudio/install/install-visual-studio)
 
-## Enable the preview feature
+## Install and enable the preview feature
+  
+1. Install [Visual Studio Preview](https://visualstudio.microsoft.com/vs/preview/) 
+   
+   Note: this is different from Visual Studio. If you have the non-preview version of Visual Studio, you still need to install this. 
 
-1. Open Visual Studio.
+2. Open Visual Studio Preview.
 
-1. From the **Tools** menu, select **Options** > **Preview Features**.
+3. From the **Tools** menu, select **Options** > **Preview Features**.
 
-1. Make sure **Integration with azd, the Azure Developer CLI** is enabled.
+4. Make sure **Integration with azd, the Azure Developer CLI** is enabled.
 
    :::image type="content" source="../media/debug/visual-studio-options.png" alt-text="Screenshot of the Visual Studio option to turn on integration with the Azure Developer CLI.":::
 


### PR DESCRIPTION
currently the preqreqs say user must have Visual Studio version later than 17.3.0 Preview 2. 

They need to have Visual Studio _Preview_ installed, which is a separate installation from Visual Studio. So, removing the prereq and adding installing Visual Studio Preview as the first step. 