### PR TITLE
Add new dev intro guide page for service/SDK/tools versioning principles

### DIFF
--- a/articles/intro/TOC.yml
+++ b/articles/intro/TOC.yml
@@ -16,6 +16,8 @@ items:
         href: azure-developer-key-concepts.md
       - name: Overview of Azure billing
         href: azure-developer-billing.md
+      - name: Versioning principles for services, SDKs and tools
+        href: azure-sdk-cli-tool-versioning.md
   - name: Passwordless connections for Azure services
     items:
       - name: Overview

--- a/articles/intro/azure-sdk-cli-tool-versioning.md
+++ b/articles/intro/azure-sdk-cli-tool-versioning.md
@@ -1,0 +1,30 @@
+---
+title: Versioning principles for services, SDKs and tools
+description: TODO Versioning principles for services, SDKs and tools
+keywords: version, azure services, azure powershell, azure sdk, azure rest apis
+ms.service: azure-devops
+ms.subservice: azure-devops-reference
+ms.topic: overview
+ms.date: 02/10/2023
+ms.custom: overview
+---
+
+# Versioning principles for services, SDKs and tools
+
+Summarize and link to overall versioning principles; this will be the "home page" for those concerns.
+
+TODO also consider https://learn.microsoft.com/azure/guides/developer/azure-developer-guide
+
+TODO add highlightedcontent item in ../index.yml?
+
+## Azure REST Service versioning and `api-version`
+
+https://learn.microsoft.com/rest/api/azure/
+
+## Azure service SDK versioning
+
+## Azure command line tools versioning (azcli, Azure PowerShell, azd)
+
+## Further reading
+
+Consider linking to https://github.com/Azure/azure-rest-api-specs and https://github.com/microsoft/api-guidelines for additional info


### PR DESCRIPTION
One of a set of changes across a few different repos to integrate Jeffrey Richter's [authoritative versioning principles document](https://microsoft-my.sharepoint.com/:w:/p/jeffreyr/ESML1cAoxDJIoNyJHHlgYDgBx7oWin6Jnp6bmM9xAG9YkQ?e=3LTPyq) into Learn documentation.

C+E Skilling work item: https://dev.azure.com/msft-skilling/Content/_workitems/edit/27940

See also:
- https://github.com/Azure/azure-docs-rest-apis/pull/5196