### PR TITLE
Added note for supported JDK version for JDK HTTP Client

### DIFF
--- a/articles/java/sdk/http-client-pipeline.md
+++ b/articles/java/sdk/http-client-pipeline.md
@@ -20,7 +20,10 @@ Although Netty is the default HTTP client, the SDK provides three client impleme
 
 * [Netty](https://netty.io)
 * [OkHttp](https://square.github.io/okhttp/)
-* The new [HttpClient](https://openjdk.java.net/groups/net/httpclient/intro.html) introduced in JDK 11
+* [HttpClient](https://openjdk.java.net/groups/net/httpclient/intro.html) introduced in JDK 11
+
+> [!NOTE]
+> The JDK HttpClient in combination with the Azure SDK for Java is only supported from JDK 12 and newer.
 
 ### Replace the default HTTP client
 


### PR DESCRIPTION
See https://github.com/Azure/azure-sdk-for-java/pull/33576 and https://github.com/Azure/azure-sdk-for-java/issues/33575

We only support the internal SDK HttpClient from JDK 12 and above, this should be reflected in our docs.