### PR TITLE
Typo fix - update to Build a .NET MAUI app with Azure Mobile Apps article and offline sync articles

### DIFF
--- a/articles/mobile-apps/azure-mobile-apps/howto/data-sync.md
+++ b/articles/mobile-apps/azure-mobile-apps/howto/data-sync.md
@@ -21,7 +21,10 @@ Offline sync has several benefits:
 
 The following tutorials show how to add offline sync to your mobile clients using Azure Mobile Apps:
 
+* [Avalonia: Enable offline sync](../quickstarts/avalonia/offline.md)
+* [.NET MAUI: Enable offline sync](../quickstarts/maui/offline.md)
 * [Windows (UWP): Enable offline sync](../quickstarts/uwp/offline.md)
+* [Windows (WinUI3): Enable offline sync](../quickstarts/winui/offline.md)
 * [Windows (WPF): Enable offline sync](../quickstarts/wpf/offline.md)
 * [Xamarin.Android: Enable offline sync](../quickstarts/xamarin-android/offline.md)
 * [Xamarin.Forms: Enable offline sync](../quickstarts/xamarin-forms/offline.md)

--- a/articles/mobile-apps/azure-mobile-apps/quickstarts/maui/index.md
+++ b/articles/mobile-apps/azure-mobile-apps/quickstarts/maui/index.md
@@ -191,11 +191,10 @@ Once the app has started, you'll see an empty list and a text box to add items i
 
    ![Screenshot showing how to set the run configuration for a dot net maui for windows app.](./media/win-windows-configuration.png)
 
-   If you do not see an Android device, select **Manage Android Devices...**
 
 4. Press **F5** to build and run the project.
 
-Once the app has started, you'll see an empty list and a text box to add items in the emulator.  You can:
+Once the app has started, you'll see an empty list and a text box to add items.  You can:
 
 * Enter some text in the box, then press Enter to insert a new item.
 * Select an item to set or clear the completed flag.


### PR DESCRIPTION
- In offline sync article, add references to offline sync tutorials of .NET MAUI, Avalonia and Windows (WinUI3).
- In Build a .NET MAUI app with Azure Mobile Apps article, remove (If you do not see an Android device...) line and (... in the emulator.) from (Build and run the Windows app) section. This deletes mentions of Android emulator on Windows app test.