### PR TITLE
Update azure-sdk-configure-proxy.md: Replace Azure CLI with command line

### DIFF
--- a/articles/python/sdk/azure-sdk-configure-proxy.md
+++ b/articles/python/sdk/azure-sdk-configure-proxy.md
@@ -20,7 +20,7 @@ To configure a proxy globally for your script or app, define `HTTP_PROXY` or `HT
 
 These environment variables are ignored if you pass the parameter `use_env_settings=False` to a client object constructor or operation method.
 
-### Set from the Azure CLI
+### Set from the command line
 
 #### [cmd](#tab/cmd)
 


### PR DESCRIPTION
Setting a proxy is not related to Azure CLI. It should be a generic command line operation.

The commands for setting environment variables are also incorrect:

https://learn.microsoft.com/en-us/azure/developer/python/sdk/azure-sdk-configure-proxy?tabs=bash

![image](https://user-images.githubusercontent.com/4003950/233895280-9405250b-a38b-40a7-bb08-aef8370957c4.png)

I have created PR https://github.com/MicrosoftDocs/python-sdk-docs-examples/pull/25 to fix them.
