### PR TITLE
Fix linux (script) update instructions for azd

### DIFF
--- a/articles/azure-developer-cli/install-azd.md
+++ b/articles/azure-developer-cli/install-azd.md
@@ -159,13 +159,8 @@ curl -fsSL https://aka.ms/install-azd.sh | bash
 
 ### Update `azd`
 ```bash
-curl -fsSL https://aka.ms/uninstall-azd.sh | bash
+curl -fsSL https://aka.ms/install-azd.sh | bash
 ```
-
-When you install `azd`, the following tools are installed within `azd` scope (meaning they are not installed globally) and are removed if azd is uninstalled:
-
-- The [Git CLI](https://cli.github.com/)
-- The [Bicep CLI](/azure/azure-resource-manager/bicep/install)
 
 ### Uninstall `azd`
 


### PR DESCRIPTION
The update script documentation currently incorrectly references the uninstall script.

Also, remove the duplicated text below upgrade. It is already listed on the same page.