### PR TITLE
Add a note about custom tabs support when targeting Android API 30 or higher

### DIFF
--- a/articles/mobile-apps/azure-mobile-apps/quickstarts/maui/authentication.md
+++ b/articles/mobile-apps/azure-mobile-apps/quickstarts/maui/authentication.md
@@ -182,6 +182,18 @@ namespace TodoApp.MAUI
 
 Replace `{client-id}` with the application ID of the native client (which is the same as `Constants.ApplicationId`).
 
+If your project's Target Android version is set to **Android 11 (R API 30)** or higher, you must update your _Android Manifest_ with queries that use Android's [package visibility requirements](https://developer.android.com/preview/privacy/package-visibility).
+
+In the _Platforms/Android/AndroidManifest.xml_ file, add the following `queries/intent` nodes in the `manifest` node:
+
+```xml
+<queries>
+  <intent>
+    <action android:name="android.support.customtabs.action.CustomTabsService" />
+  </intent>
+</queries>
+```
+
 Open `MauiProgram.cs`.  Include the following `using` statements at the top of the file:
 
 ``` csharp


### PR DESCRIPTION
Added the custom tabs support note from
https://learn.microsoft.com/en-us/dotnet/maui/platform-integration/communication/authentication?tabs=android#get-started
to
https://learn.microsoft.com/en-us/azure/developer/mobile-apps/azure-mobile-apps/quickstarts/maui/authentication?pivots=vs2022-windows#configure-the-android-app-for-authentication