### PR TITLE
Clarify permissions on resource group scoped deployment

### DIFF
--- a/articles/azure-developer-cli/resource-group-scoped-deployments.md
+++ b/articles/azure-developer-cli/resource-group-scoped-deployments.md
@@ -10,7 +10,9 @@ ms.custom: devx-track-azdevcli
 ---
 
 # Resource Group Scoped Deployments [Alpha]
-Azure Developer CLI (azd) supports deployments at the subscription level as well as at a resource group scope. By default, `azd` will deploy to the subscription you choose and then create a resource group in that subscription to store your services in. If you would like to deploy to an existing resource group, you can use `azd` to do so.
+Azure Developer CLI (azd) supports deployments at the subscription level as well as at a resource group scope. By default, `azd` will deploy to the subscription you choose and then create a resource group in that subscription to store your services in. If you would like to deploy to an existing resource group, you can use `azd` to do so. By choosing an existing resource group, the scope of permissions needed to run `azd provision` is reduced from subscription level to the resource group scope.
+
+In this article, you will learn how to modify templates to enable resource group scoped deployments.
 
 > [!NOTE]
 > Resource Group Scoped Deployment is currently an alpha feature, so to deploy to a resource group, you need to enable it by running the following:


### PR DESCRIPTION
Add a clarifying note that explains how resource group scoped deployments affect permissions needed since there's been recent user asks around it.
