### PR TITLE
Updates `azd` hook config docs based on azd updates

### DIFF
--- a/articles/azure-developer-cli/azd-extensibility.md
+++ b/articles/azure-developer-cli/azd-extensibility.md
@@ -43,7 +43,7 @@ Hooks can be registered in your `azure.yaml` file at the root or within a specif
   * *Note*: PowerShell 7 is required for `pwsh`.
 * `run`: Define an inline script or a path to a file.
 * `continueOnError`: When set will continue to execute even after a script error occurred during a command hook (default false).
-* `interactive`: When set will bind the running script to the console `stdin`, `stdout` & `stderr` (default false). This property need to be set to `true` in order to see the hook's output.
+* `interactive`: When set will bind the running script to the console `stdin`, `stdout` & `stderr` (default false).
 * `windows`: Specifies that the nested configurations will only apply on windows OS. If this configuration option is excluded, the hook executes on all platforms.
 * `posix`: Specifies that the nested configurations will only apply to POSIX based OSes (Linux & MaxOS). If this configuration option is excluded, the hook executes on all platforms.
 


### PR DESCRIPTION
A recent change (Azure/azure-dev#2792) was introduced within `azd` that modified the behavior of when hooks script output is displayed in the console.  Hook output is now always displayed within a `preview` experience as the script is executing.