### PR TITLE
Fix copy-paste error in user login examples table

### DIFF
--- a/articles/dev-tunnels/cli-commands.md
+++ b/articles/dev-tunnels/cli-commands.md
@@ -47,7 +47,7 @@ Here are some examples on use of these commands:
 |-----------------------------------|---------------------------------------------------------|
 | `devtunnel user login`     | Login with a Microsoft organization (Microsoft Entra ID) or personal account |
 | `devtunnel user login -g`  | Login with a GitHub account |
-| `devtunnel user login -d`  | Login with a GitHub account  with _device code login_, if local interactive browser login isn't possible  |
+| `devtunnel user login -d`  | Login with a Microsoft organization (Microsoft Entra ID) or personal account with _device code login_, if local interactive browser login isn't possible  |
 | `devtunnel user login -g -d`  | Login with a GitHub account with _device code login_, if local interactive browser login isn't possible |
 
 ## Host a dev tunnel


### PR DESCRIPTION
No `-g` option on that line means it's not a GtiHub account.  Default is the MS account.