### PR TITLE
Java Azure SDK logging: add details on how to enable HTTP logs

### DIFF
--- a/articles/java/sdk/logging-overview.md
+++ b/articles/java/sdk/logging-overview.md
@@ -23,6 +23,40 @@ Whatever logging configuration you use, the same log output is available in eith
 
 The rest of this article details the configuration of all available logging options.
 
+## Enable HTTP request/response logging
+
+HTTP request and response logging is off by default. Clients that communicate to Azure services over HTTP can be configured to write a log for each request and response (or exception) they received.
+To enable logs, pass a configured instance of [`HttpLogOptions`](https://learn.microsoft.com/java/api/com.azure.core.http.policy.httplogoptions) to the `httpLogOptions` method on the
+corresponding client builder.
+
+Here's an example for App Configuration service:
+
+```java
+ConfigurationClient configurationClient = new ConfigurationClientBuilder()
+        .connectionString(connectionString)
+        .httpLogOptions(new HttpLogOptions().setLogLevel(HttpLogDetailLevel.HEADERS))
+        .buildClient();
+```
+
+In the above example, we enable logs enriched with request and response headers. Only headers from the configurable allow list are included, others are redacted.
+You can add or override a list of headers allowed by default.
+
+You can change the level of details by providing a different value of the [`HttpLogDetailLevel`](https://learn.microsoft.com/java/api/com.azure.core.http.policy.httplogdetaillevel?view=azure-java-stable) enum.
+
+For example, when `HttpLogDetailLevel.BASIC` level is configured, produced logs contain request method, sanitized request URL, try count, response code, and the content length for request and response bodies.
+
+> Note:
+> The request URL is sanitized by default - all query parameter values are redacted except for configurable allow list.
+
+For example, Azure Blob Storage SAS URL is logged in the following format:
+`https://myaccount.blob.core.windows.net/pictures/profile.jpg?sv=REDACTED&st=REDACTED&se=REDACTED&sr=REDACTED&sp=REDACTED&rscd=REDACTED&rsct=REDACTED&sig=REDACTED`
+
+The `HttpLogDetailLevel.HEADERS` we used in the example above includes all the basic details and allowed headers. And the `HttpLogDetailLevel.BODY_AND_HEADERS` level adds request and response bodies as long as they are smaller than 16 KB and printable.
+
+Check [`HttpLogOptions`](https://learn.microsoft.com/java/api/com.azure.core.http.policy.httplogoptions) documentation for the full list of configuration options.
+
+If you use OpenTelemetry, you may consider using distributed tracing instead of logging for HTTP requests, refer to the [Distributed Tracing](./tracing.md) article for the details.
+
 ## Default logger (for temporary debugging)
 
 As noted, all Azure client libraries use SLF4J for logging, but there's a fallback, default logger built into Azure client libraries for Java. This default logger is provided for cases where an application has been deployed, and logging is required, but it's not possible to redeploy the application with an SLF4J logger included. To enable this logger, you must first be certain that no SLF4J logger exists (because it takes precedence), and then set the `AZURE_LOG_LEVEL` environment variable. The following table shows the values allowed for this environment variable:
@@ -64,7 +98,7 @@ In addition to logging the common properties mentioned earlier, Azure client lib
 When you send logs to Azure Monitor, you can use the [Kusto query language](/azure/data-explorer/kusto/query/) to parse them. The following query provides an example:
 
 ```kusto
-traces 
+traces
 | where message startswith "{\"az.sdk.message"
 | project timestamp, logger=customDimensions["LoggerName"], level=customDimensions["LoggingLevel"], thread=customDimensions["ThreadName"], azSdkContext=parse_json(message)
 | evaluate bag_unpack(azSdkContext)
@@ -80,3 +114,4 @@ Now that you've seen how logging works in the Azure SDK for Java, consider revie
 * [java.util.logging](logging-jul.md)
 * [Logback](logging-logback.md)
 * [Log4J](logging-log4j.md)
+* [Tracing](tracing.md)


### PR DESCRIPTION
Adds details on how to enable HTTP logging in Azure SDK for Java