### PR TITLE
Replaced deprecated Go function

### DIFF
--- a/articles/go/deploy-azure-resource-manager-template.md
+++ b/articles/go/deploy-azure-resource-manager-template.md
@@ -82,7 +82,7 @@ var (
 )
 
 func readJSON(path string) (map[string]interface{}, error) {
-	data, err := ioutil.ReadFile(path)
+	data, err := os.ReadFile(path)
 	if err != nil {
 		log.Fatalf("failed to read file: %v", err)
 	}

--- a/articles/go/deploy-azure-resource-manager-template.md
+++ b/articles/go/deploy-azure-resource-manager-template.md
@@ -61,7 +61,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 


### PR DESCRIPTION
ioutil.ReadFile is deprecated: As of Go 1.16, this function simply calls [os.ReadFile].