### PR TITLE
Update application-gateway-configure.md

### DIFF
--- a/articles/ansible/application-gateway-configure.md
+++ b/articles/ansible/application-gateway-configure.md
@@ -214,8 +214,8 @@ Save the following playbook as `appgw_create.yml`:
         resource_group: "{{ resource_group }}"
         name: "{{ appgw_name }}"
         sku:
-          name: standard_small
-          tier: standard
+          name: standard_v2
+          tier: standard_v2
           capacity: 2
         gateway_ip_configurations:
           - subnet:


### PR DESCRIPTION
When running current playbook, the following error happened.

```
TASK [Create instance of Application Gateway] ********************************************************************************************************
fatal: [localhost]: FAILED! => {"changed": false, "msg": "Error creating the Application Gateway instance: (AppGatewayV1SkuDeprecated) Application Gateway SKU tier Standard has been deprecated. Supported SKU tiers are Standard_v2,WAF_v2. Refer https://aka.ms/V1retirement.\nCode: AppGatewayV1SkuDeprecated\nMessage: Application Gateway SKU tier Standard has been deprecated. Supported SKU tiers are Standard_v2,WAF_v2. Refer https://aka.ms/V1retirement."}
```
So this updates the doc for the latest Azure behavior.