### PR TITLE
docs: Add missing pip install azure.storage.blob

### DIFF
--- a/articles/python/sdk/authentication-azure-hosted-apps.md
+++ b/articles/python/sdk/authentication-azure-hosted-apps.md
@@ -113,13 +113,13 @@ For information on assigning permissions at the resource or subscription level u
 When your code is running in Azure and managed identity has been enabled on the Azure resource hosting your app, the [`DefaultAzureCredential`](/python/api/azure-identity/azure.identity.defaultazurecredential) determines the credentials to use in the following order:
 
 1. Check the environment for a service principal as defined by the environment variables `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, and either `AZURE_CLIENT_SECRET` or `AZURE_CLIENT_CERTIFICATE_PATH` and (optionally) `AZURE_CLIENT_CERTIFICATE_PASSWORD`.
-1. Check keyword parameters for a user-assigned managed identity. You can pass in a user-assigned managed identity by specifying its client ID in the `managed_identity_client_id` parameter.
-1. Check the `AZURE_CLIENT_ID` environment variable for the client ID of a user-assigned managed identity.
-1. Use the system-assigned managed identity for the Azure resource if it's enabled.
+2. Check keyword parameters for a user-assigned managed identity. You can pass in a user-assigned managed identity by specifying its client ID in the `managed_identity_client_id` parameter.
+3. Check the `AZURE_CLIENT_ID` environment variable for the client ID of a user-assigned managed identity.
+4. Use the system-assigned managed identity for the Azure resource if it's enabled.
 
-You can exclude managed identities from the credential by setting the `exclude_managed_identity_credential` keyword parameter `True`.
+You can exclude managed identities from the credential by setting the `exclude_managed_identity_credential` keyword parameter `True`. You may also choose to use the `BlobServiceClient` from the `azure.storage.blob` package to interact with an [Azure Storage Account](https://learn.microsoft.com/azure/storage/common/storage-account-overview).
 
-In this article, we're using the system-assigned managed identity for an Azure App Service web app, so we don't need to configure a managed identity in the environment or pass it in as a parameter. The following steps show you how to use `DefaultAzureCredential`.
+In this article, we're using the system-assigned managed identity for an Azure App Service web app, so we don't need to configure a managed identity in the environment or pass it in as a parameter. The following steps show you how to use `DefaultAzureCredential` and `BlobServiceClient`.
 
 First, add the `azure.identity` package to your application.
 
@@ -127,11 +127,17 @@ First, add the `azure.identity` package to your application.
 pip install azure-identity
 ```
 
+If your application interacts with an Azure Storage Account, add the [azure.storage.blob](https://pypi.org/project/azure-storage-blob/) package to your application.
+
+```terminal
+pip install azure-storage-blob
+```
+
 Next, for any Python code that creates an Azure SDK client object in your app, you'll want to:
 
 1. Import the `DefaultAzureCredential` class from the `azure.identity` module.
-1. Create a `DefaultAzureCredential` object.
-1. Pass the `DefaultAzureCredential` object to the Azure SDK client object constructor.
+2. Create a `DefaultAzureCredential` object.
+3. Pass the `DefaultAzureCredential` object to the Azure SDK client object constructor.
 
 An example of these steps is shown in the following code segment.
 

--- a/articles/python/sdk/authentication-local-development-dev-accounts.md
+++ b/articles/python/sdk/authentication-local-development-dev-accounts.md
@@ -159,7 +159,7 @@ DefaultAzureCredential(exclude_interactive_browser_credential=False)
 
 ## 4 - Implement DefaultAzureCredential in your application
 
-To authenticate Azure SDK client objects to Azure, your application should use the [`DefaultAzureCredential`](/python/api/azure-identity/azure.identity.defaultazurecredential) class from the `azure.identity` package. In this scenario, `DefaultAzureCredential` will sequentially check to see if the developer has signed-in to Azure using the Azure CLI, Azure PowerShell, or Azure developer CLI. If the developer is signed-in to Azure using any of these tools, then the credentials used to sign into the tool will be used by the app to authenticate to Azure.
+To authenticate Azure SDK client objects to Azure, your application should use the [`DefaultAzureCredential`](/python/api/azure-identity/azure.identity.defaultazurecredential) class from the `azure.identity` package. In this scenario, `DefaultAzureCredential` will sequentially check to see if the developer has signed-in to Azure using the Azure CLI, Azure PowerShell, or Azure developer CLI. If the developer is signed-in to Azure using any of these tools, then the credentials used to sign into the tool will be used by the app to authenticate to Azure. You may also choose to use the `BlobServiceClient` from the `azure.storage.blob` package to interact with an [Azure Storage Account](https://learn.microsoft.com/azure/storage/common/storage-account-overview).
 
 Start by adding the [azure.identity](https://pypi.org/project/azure-identity/) package to your application.
 
@@ -167,11 +167,17 @@ Start by adding the [azure.identity](https://pypi.org/project/azure-identity/) p
 pip install azure-identity
 ```
 
+If your application interacts with an Azure Storage Account, add the [azure.storage.blob](https://pypi.org/project/azure-storage-blob/) package to your application.
+
+```terminal
+pip install azure-storage-blob
+```
+
 Next, for any Python code that creates an Azure SDK client object in your app, you'll want to:
 
 1. Import the `DefaultAzureCredential` class from the `azure.identity` module.
-1. Create a `DefaultAzureCredential` object.
-1. Pass the `DefaultAzureCredential` object to the Azure SDK client object constructor.
+2. Create a `DefaultAzureCredential` object.
+3. Pass the `DefaultAzureCredential` object to the Azure SDK client object constructor.
 
 An example of these steps is shown in the following code segment.
 

--- a/articles/python/sdk/authentication-local-development-service-principal.md
+++ b/articles/python/sdk/authentication-local-development-service-principal.md
@@ -201,7 +201,7 @@ if ( os.environ['ENVIRONMENT'] == 'development'):
 
 ## 5 - Implement DefaultAzureCredential in your application
 
-To authenticate Azure SDK client objects to Azure, your application should use the `DefaultAzureCredential` class from the `azure.identity` package. In this scenario, `DefaultAzureCredential` will detect the environment variables `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`,  and `AZURE_CLIENT_SECRET` are set and read those variables to get the application service principal information to connect to Azure with.
+To authenticate Azure SDK client objects to Azure, your application should use the `DefaultAzureCredential` class from the `azure.identity` package. In this scenario, `DefaultAzureCredential` will detect the environment variables `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`,  and `AZURE_CLIENT_SECRET` are set and read those variables to get the application service principal information to connect to Azure with. You may also choose to use the `BlobServiceClient` from the `azure.storage.blob` package to interact with an [Azure Storage Account](https://learn.microsoft.com/azure/storage/common/storage-account-overview).
 
 Start by adding the [azure.identity](https://pypi.org/project/azure-identity/) package to your application.
 
@@ -209,11 +209,18 @@ Start by adding the [azure.identity](https://pypi.org/project/azure-identity/) p
 pip install azure-identity
 ```
 
+If your application interacts with an Azure Storage Account, add the [azure.storage.blob](https://pypi.org/project/azure-storage-blob/) package to your application.
+
+```terminal
+pip install azure-storage-blob
+```
+
+
 Next, for any Python code that creates an Azure SDK client object in your app, you'll want to:
 
 1. Import the `DefaultAzureCredential` class from the `azure.identity` module.
-1. Create a `DefaultAzureCredential` object.
-1. Pass the `DefaultAzureCredential` object to the Azure SDK client object constructor.
+2. Create a `DefaultAzureCredential` object.
+3. Pass the `DefaultAzureCredential` object to the Azure SDK client object constructor.
 
 An example of this is shown in the following code segment.
 

--- a/articles/python/sdk/authentication-on-premises-apps.md
+++ b/articles/python/sdk/authentication-on-premises-apps.md
@@ -127,7 +127,7 @@ AZURE_CLIENT_SECRET=<value>
 
 ## 4 - Implement DefaultAzureCredential in application
 
-To authenticate Azure SDK client objects to Azure, your application should use the `DefaultAzureCredential` class from the `azure.identity` package.
+To authenticate Azure SDK client objects to Azure, your application should use the `DefaultAzureCredential` class from the `azure.identity` package. You may also choose to use the `BlobServiceClient` from the `azure.storage.blob` package to interact with an [Azure Storage Account](https://learn.microsoft.com/azure/storage/common/storage-account-overview).
 
 Start by adding the [azure.identity](https://pypi.org/project/azure-identity/) package to your application.
 
@@ -135,11 +135,18 @@ Start by adding the [azure.identity](https://pypi.org/project/azure-identity/) p
 pip install azure-identity
 ```
 
+If your application interacts with an Azure Storage Account, add the [azure.storage.blob](https://pypi.org/project/azure-storage-blob/) package to your application.
+
+```terminal
+pip install azure-storage-blob
+```
+
+
 Next, for any Python code that creates an Azure SDK client object in your app, you'll want to:
 
 1. Import the `DefaultAzureCredential` class from the `azure.identity` module.
-1. Create a `DefaultAzureCredential` object.
-1. Pass the `DefaultAzureCredential` object to the Azure SDK client object constructor.
+2. Create a `DefaultAzureCredential` object.
+3. Pass the `DefaultAzureCredential` object to the Azure SDK client object constructor.
 
 An example of this is shown in the following code segment.
 

--- a/articles/python/sdk/authentication-overview.md
+++ b/articles/python/sdk/authentication-overview.md
@@ -61,11 +61,20 @@ When an application runs on a developer's workstation during local development, 
 
 ## Use DefaultAzureCredential in an application
 
-To use [DefaultAzureCredential](/python/api/azure-identity/azure.identity.defaultazurecredential) in a Python app, add the [azure.identity](https://pypi.org/project/azure-identity/) package to your application.
+To use [DefaultAzureCredential](/python/api/azure-identity/azure.identity.defaultazurecredential) in a Python app, add the [azure.identity](https://pypi.org/project/azure-identity/) package to your application. You may also choose to use the `BlobServiceClient` from the `azure.storage.blob` package to interact with an [Azure Storage Account](https://learn.microsoft.com/azure/storage/common/storage-account-overview).
+
+Start by adding the [azure.identity](https://pypi.org/project/azure-identity/) package to your application.
 
 ```terminal
 pip install azure-identity
 ```
+
+If your application interacts with an Azure Storage Account, add the [azure.storage.blob](https://pypi.org/project/azure-storage-blob/) package to your application.
+
+```terminal
+pip install azure-storage-blob
+```
+
 
 The following code example shows how to instantiate a `DefaultAzureCredential` object and use it with an Azure SDK client class. In this case, it's a `BlobServiceClient` object used to access Azure Blob Storage.
 


### PR DESCRIPTION
Adds missing command to install azure.storage.blob python package as referenced in the code examples. Without this, users may not know proper install steps. Fixes sequence of numbered bullets.