### PR TITLE
Update tutorial-containerize-simple-web-app-for-app-service.md

### DIFF
--- a/articles/python/tutorial-containerize-simple-web-app-for-app-service.md
+++ b/articles/python/tutorial-containerize-simple-web-app-for-app-service.md
@@ -277,7 +277,8 @@ The `--registry` option specifies the registry name, and the `--image` option sp
     --role AcrPull \
     --scope /subscriptions/$SUBSCRIPTION_ID/resourceGroups/web-app-simple-rg \
     --acr-use-identity --acr-identity [system] \
-    --container-image-name webappacr123.azurecr.io/webappsimple:latest 
+    --container-image-name webappacr123.azurecr.io/webappsimple:latest
+    --startup-file startup.sh
     ```
 
     Notes:


### PR DESCRIPTION
The startup-file flag was not set when creating the web app resulting in the web app not working. The web app would simply remain stuck at 'loading' in the browser. Fortunately the startup.sh was given, but simply not used.