### PR TITLE
Update java version requirement

### DIFF
--- a/articles/jenkins/configure-on-linux-vm.md
+++ b/articles/jenkins/configure-on-linux-vm.md
@@ -45,7 +45,7 @@ In this article, you'll learn how to:
     #cloud-config
     package_upgrade: true
     runcmd:
-      - sudo apt install openjdk-11-jre -y
+      - sudo apt install openjdk-17-jre -y
       - curl -fsSL https://pkg.jenkins.io/debian-stable/jenkins.io-2023.key | sudo tee /usr/share/keyrings/jenkins-keyring.asc > /dev/null
       -  echo 'deb [signed-by=/usr/share/keyrings/jenkins-keyring.asc] https://pkg.jenkins.io/debian-stable binary/' | sudo tee /etc/apt/sources.list.d/jenkins.list > /dev/null
       - sudo apt-get update && sudo apt-get install jenkins -y


### PR DESCRIPTION
When following the docs Jenkins fails to start with the following error

```
Running with Java 11 from /usr/lib/jvm/java-11-openjdk-amd64, which is older than the mini>
Supported Java versions are: [17, 21]
```

Updating to Java 17 resolved the issue.