### PR TITLE
Add Maven dependency for JDK HttpClient; update versions

### DIFF
--- a/articles/java/sdk/http-client-pipeline.md
+++ b/articles/java/sdk/http-client-pipeline.md
@@ -36,7 +36,7 @@ The following example shows you how to exclude the Netty dependency from a real 
 <dependency>
     <groupId>com.azure</groupId>
     <artifactId>azure-security-keyvault-secrets</artifactId>
-    <version>4.2.2.</version>
+    <version>4.9.4</version>
     <exclusions>
       <exclusion>
         <groupId>com.azure</groupId>
@@ -45,10 +45,18 @@ The following example shows you how to exclude the Netty dependency from a real 
     </exclusions>
 </dependency>
 
+<!-- OkHttp -->
 <dependency>
   <groupId>com.azure</groupId>
   <artifactId>azure-core-http-okhttp</artifactId>
-  <version>1.3.3</version>
+  <version>1.12.10</version>
+</dependency>
+
+<!-- JDK 11 HttpClient -->
+<dependency>
+  <groupId>com.azure</groupId>
+  <artifactId>azure-core-http-jdk-httpclient</artifactId>
+  <version>1.0.3</version>
 </dependency>
 ```
 

--- a/articles/java/sdk/http-client-pipeline.md
+++ b/articles/java/sdk/http-client-pipeline.md
@@ -52,7 +52,7 @@ The following example shows you how to exclude the Netty dependency from a real 
   <version>1.12.10</version>
 </dependency>
 
-<!-- JDK 11 HttpClient -->
+<!-- JDK HttpClient -->
 <dependency>
   <groupId>com.azure</groupId>
   <artifactId>azure-core-http-jdk-httpclient</artifactId>
@@ -67,7 +67,7 @@ The following example shows you how to exclude the Netty dependency from a real 
 
 When you build a service client, it defaults to using `HttpClient.createDefault()`. This method returns a basic `HttpClient` instance based on the provided HTTP client implementation. In case you require a more complex HTTP client, such as a proxy, each implementation offers a builder that allows you to construct a configured `HttpClient` instance. The builders are `NettyAsyncHttpClientBuilder`, `OkHttpAsyncHttpClientBuilder`, and `JdkAsyncHttpClientBuilder`.
 
-The following examples show how to build `HttpClient` instances using Netty, OkHttp, and the JDK 11 HTTP client. These instances proxy through `http://localhost:3128` and authenticate with user `example` with password `weakPassword`.
+The following examples show how to build `HttpClient` instances using Netty, OkHttp, and the JDK HTTP client. These instances proxy through `http://localhost:3128` and authenticate with user `example` with password `weakPassword`.
 
 ```java
 // Netty
@@ -82,7 +82,7 @@ HttpClient httpClient = new OkHttpAsyncHttpClientBuilder()
         .setCredentials("example", "weakPassword"))
     .build();
 
-// JDK 11 HttpClient
+// JDK HttpClient
 HttpClient client = new JdkAsyncHttpClientBuilder()
     .proxy(new ProxyOptions(ProxyOptions.Type.HTTP, new InetSocketAddress("localhost", 3128))
         .setCredentials("example", "weakPassword"))


### PR DESCRIPTION
I had trouble finding the artifact for the JDK HttpClient which I think belongs in this doc. I also updated the versions of the others to be current.