### PR TITLE
Include link to copilot enable/disable in azure

### DIFF
--- a/articles/github-copilot-azure/get-started.md
+++ b/articles/github-copilot-azure/get-started.md
@@ -18,6 +18,8 @@ To complete the steps in this article, make sure that you have:
 
 [!INCLUDE [ghcpa-prerequisites](includes/prerequisites.md)]
 
+By default, Copilot in Azure is available to all users in a tenant. However, Global Administrators can manage access to Copilot in Azure for their organization. Access can also be optionally granted to specific Microsoft Entra users or groups. See https://learn.microsoft.com/en-us/azure/copilot/manage-access for more information
+
 ## Install GitHub Copilot for Azure
 
 1. In Visual Studio Code, select the **Extensions** icon.

--- a/articles/github-copilot-azure/get-started.md
+++ b/articles/github-copilot-azure/get-started.md
@@ -18,7 +18,7 @@ To complete the steps in this article, make sure that you have:
 
 [!INCLUDE [ghcpa-prerequisites](includes/prerequisites.md)]
 
-By default, Copilot in Azure is available to all users in a tenant. However, Global Administrators can manage access to Copilot in Azure for their organization. Access can also be optionally granted to specific Microsoft Entra users or groups. See https://learn.microsoft.com/en-us/azure/copilot/manage-access for more information
+By default, Copilot in Azure is available to all users in a tenant. However, Global Administrators can manage access to Copilot in Azure for their organization. Access can also be optionally granted to specific Microsoft Entra users or groups. For more information, see [Manage access to Microsoft Copilot in Azure](/azure/copilot/manage-access).
 
 ## Install GitHub Copilot for Azure
 


### PR DESCRIPTION
All copilot products that access azure can be disabled using the setting defined in this new link. Individual users can be added to an RBAC group to override. Adding a link to make that clear