### PR TITLE
Rename `storage_account_name` to `storage_account_id` due to deprecation

### DIFF
--- a/articles/terraform/store-state-in-azure-storage.md
+++ b/articles/terraform/store-state-in-azure-storage.md
@@ -115,7 +115,7 @@ resource "azurerm_storage_account" "tfstate" {
 
 resource "azurerm_storage_container" "tfstate" {
   name                  = "tfstate"
-  storage_account_id    = azurerm_storage_account.tfstate.name
+  storage_account_id    = azurerm_storage_account.tfstate.id
   container_access_type = "private"
 }
 ```

--- a/articles/terraform/store-state-in-azure-storage.md
+++ b/articles/terraform/store-state-in-azure-storage.md
@@ -115,7 +115,7 @@ resource "azurerm_storage_account" "tfstate" {
 
 resource "azurerm_storage_container" "tfstate" {
   name                  = "tfstate"
-  storage_account_name  = azurerm_storage_account.tfstate.name
+  storage_account_id    = azurerm_storage_account.tfstate.name
   container_access_type = "private"
 }
 ```


### PR DESCRIPTION
This PR renames `storage_account_name` to `storage_account_id` as the former [has been deprecated](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_container#storage_account_name-1)