### PR TITLE
Update free account link in quickstart note

### DIFF
--- a/articles/includes/quickstarts-free-trial-note.md
+++ b/articles/includes/quickstarts-free-trial-note.md
@@ -1,1 +1,1 @@
-If you don't have an [Azure subscription](/azure/developer/intro/azure-developer-billing#what-is-an-azure-subscription), create a [free account](https://azure.microsoft.com/free/?ref=microsoft.com&utm_source=microsoft.com&utm_medium=docs&utm_campaign=visualstudio) before you begin.
+If you don't have an [Azure subscription](/azure/developer/intro/azure-developer-billing#what-is-an-azure-subscription), create a [free account](https://azure.microsoft.com/pricing/purchase-options/azure-account?cid=msft_learn) before you begin.


### PR DESCRIPTION
This change allows us to track trial sign ups from Learn beyond the click.