### PR TITLE
Restore sovereign clouds entry to azure-mcp-server TOC

### DIFF
--- a/articles/azure-mcp-server/TOC.yml
+++ b/articles/azure-mcp-server/TOC.yml
@@ -44,6 +44,8 @@ items:
         href: how-to/github-copilot-cli.md
       - name: GitHub Copilot SDK
         href: how-to/github-copilot-sdk.md
+      - name: Sovereign clouds
+        href: how-to/connect-sovereign-clouds.md
 - name: Self-host
   expanded: true
   items:


### PR DESCRIPTION
## Summary

The **Connect Azure MCP Server to sovereign clouds** how-to page was accidentally removed from the TOC during the April 14 TOC flattening (commit cc8009a0). The file still exists at `articles/azure-mcp-server/how-to/connect-sovereign-clouds.md` — this restores its entry under **How to > Connect**.

## What changed

- Added `Sovereign clouds` entry back to `articles/azure-mcp-server/TOC.yml` under the Connect section

Reported by Sandeep Sen.