### PR TITLE
Update Java SDK sample links to migrated azure-sdk-for-java location

### DIFF
--- a/articles/java/sdk/includes/java-container-samples.md
+++ b/articles/java/sdk/includes/java-container-samples.md
@@ -1,9 +1,9 @@
 | Sample  | Description |
 |---------|---------|
 | [Manage Azure Container Registries][1] | Create a new Azure Container registry and add an new image. | 
-| [Manage Azure Container Service][2] | Create an Azure Container Service with Kubernetes orchestration. | 
+| [Manage Azure Kubernetes Service][2] | Create an Azure Kubernetes Service (AKS) cluster with Kubernetes orchestration. | 
 | [Deploy an image from Azure Container Registry into a new Linux Web App][3] | Deploy a Docker image running Tomcat to a new web app running in Azure App Service for Linux. | 
 
-[1]: https://github.com/Azure-Samples/acr-java-manage-azure-container-registry/
-[2]: https://github.com/azure-samples/acs-java-manage-azure-container-service-with-kubernetes-orchestrator
-[3]: https://github.com/Azure-Samples/app-service-java-deploy-image-from-acr-to-linux/
+[1]: https://github.com/Azure/azure-sdk-for-java/blob/main/sdk/resourcemanager/azure-resourcemanager/src/samples/java/com/azure/resourcemanager/containerregistry/samples/ManageContainerRegistry.java
+[2]: https://github.com/Azure/azure-sdk-for-java/blob/main/sdk/resourcemanager/azure-resourcemanager/src/samples/java/com/azure/resourcemanager/containerservice/samples/ManageKubernetesCluster.java
+[3]: https://github.com/Azure/azure-sdk-for-java/blob/main/sdk/resourcemanager/azure-resourcemanager/src/samples/java/com/azure/resourcemanager/appservice/samples/DeployImageFromAcrToLinuxWebApp.java

--- a/articles/java/sdk/includes/java-sql-samples.md
+++ b/articles/java/sdk/includes/java-sql-samples.md
@@ -4,6 +4,6 @@
 | [Create and manage SQL databases][1] | Create SQL databases, set performance levels, and configure firewalls.|
 | [Manage SQL databases across multiple regions][2] | Create a master SQL database and read-only databases from the master in multiple regions. Connect VMs to their nearest SQL database instance with a virtual network and firewall rules. | 
 
-[1]: https://github.com/Azure-Samples/sql-database-java-manage-db/
-[2]: https://github.com/Azure-Samples/sql-database-java-manage-sql-databases-across-regions
+[1]: https://github.com/Azure/azure-sdk-for-java/blob/main/sdk/resourcemanager/azure-resourcemanager/src/samples/java/com/azure/resourcemanager/sql/samples/ManageSqlDatabase.java
+[2]: https://github.com/Azure/azure-sdk-for-java/blob/main/sdk/resourcemanager/azure-resourcemanager/src/samples/java/com/azure/resourcemanager/sql/samples/ManageSqlDatabasesAcrossRegions.java
 [3]: /azure/sql-database/sql-database-connect-query-java

--- a/articles/java/sdk/includes/java-vm-samples.md
+++ b/articles/java/sdk/includes/java-vm-samples.md
@@ -4,6 +4,6 @@
 | [Create a virtual machine using specialized VHD from a snapshot][2] | Create snapshot from the virtual machine's OS and data disks, create managed disks from the snapshots, and then create a virtual machine by attaching the managed disks. |  
 | [Create virtual machines in parallel in the same network][3] | Create virtual machines in the same region on the same virtual network with two subnets in parallel. |
 
-[1]: https://github.com/Azure-Samples/managed-disk-java-create-virtual-machine-using-custom-image/
-[2]: https://github.com/Azure-Samples/managed-disk-java-create-virtual-machine-using-specialized-disk-from-vhd/
-[3]: https://github.com/Azure-Samples/compute-java-manage-virtual-machines-in-parallel/
+[1]: https://github.com/Azure/azure-sdk-for-java/blob/main/sdk/resourcemanager/azure-resourcemanager/src/samples/java/com/azure/resourcemanager/compute/samples/CreateVirtualMachineUsingCustomImageFromVM.java
+[2]: https://github.com/Azure/azure-sdk-for-java/blob/main/sdk/resourcemanager/azure-resourcemanager/src/samples/java/com/azure/resourcemanager/compute/samples/CreateVirtualMachineUsingSpecializedDiskFromSnapshot.java
+[3]: https://github.com/Azure/azure-sdk-for-java/blob/main/sdk/resourcemanager/azure-resourcemanager/src/samples/java/com/azure/resourcemanager/compute/samples/ManageVirtualMachinesInParallel.java

--- a/articles/java/sdk/web-apps-samples.md
+++ b/articles/java/sdk/web-apps-samples.md
@@ -16,7 +16,6 @@ The following table links to Java source code you can use to create and configur
 | Sample | Description |
 |---|---|
 | **Create an app** ||
-| [Create a web app and deploy from FTP or GitHub][1] | Deploy web apps from local Git, FTP, and continuous integration from GitHub. |
 | [Create a web app and manage deployment slots][2] | Create a web app and deploy to staging slots, and then swap deployments between slots. |
 | **Configure an app** ||
 | [Create a web app and configure a custom domain][3] | Create a web app with a custom domain and self-signed SSL certificate. |
@@ -26,9 +25,8 @@ The following table links to Java source code you can use to create and configur
 | [Connect a web app to a storage account][5] | Create an Azure storage account and add the storage account connection string to the app settings. |
 | [Connect a web app to a SQL database][6] | Create a web app and SQL database, and then add the SQL database connection string to the app settings. |
 
-[1]: ./index.yml
-[2]: https://github.com/Azure-Samples/app-service-java-manage-staging-and-production-slots-for-web-apps/
-[3]: https://github.com/Azure-Samples/app-service-java-manage-web-apps-with-custom-domains/
-[4]: https://github.com/Azure-Samples/app-service-java-scale-web-apps-on-linux
-[5]: https://github.com/Azure-Samples/app-service-java-manage-storage-connections-for-web-apps/
-[6]: https://github.com/Azure-Samples/app-service-java-manage-data-connections-for-web-apps/
+[2]: https://github.com/Azure/azure-sdk-for-java/blob/main/sdk/resourcemanager/azure-resourcemanager/src/samples/java/com/azure/resourcemanager/appservice/samples/ManageWebAppSlots.java
+[3]: https://github.com/Azure/azure-sdk-for-java/blob/main/sdk/resourcemanager/azure-resourcemanager/src/samples/java/com/azure/resourcemanager/appservice/samples/ManageWebAppWithCustomDomain.java
+[4]: https://github.com/Azure/azure-sdk-for-java/blob/main/sdk/resourcemanager/azure-resourcemanager/src/samples/java/com/azure/resourcemanager/appservice/samples/ScaleWebAppWithTrafficManager.java
+[5]: https://github.com/Azure/azure-sdk-for-java/blob/main/sdk/resourcemanager/azure-resourcemanager/src/samples/java/com/azure/resourcemanager/appservice/samples/ConnectWebAppToStorageAccount.java
+[6]: https://github.com/Azure/azure-sdk-for-java/blob/main/sdk/resourcemanager/azure-resourcemanager/src/samples/java/com/azure/resourcemanager/appservice/samples/ConnectWebAppToSqlDatabase.java


### PR DESCRIPTION
Updates the Java management-libraries sample tables to point at the samples migrated into `Azure/azure-sdk-for-java` (see Azure/azure-sdk-for-java#49923). The original `Azure-Samples` repos are archived; links now target `sdk/resourcemanager/azure-resourcemanager/src/samples/java/...` on `main`.

## Changes
- **Virtual machine samples** (`includes/java-vm-samples.md`): 3 links updated to `compute/samples/`.
- **SQL Database samples** (`includes/java-sql-samples.md`): 2 links updated to `sql/samples/` (the JDBC how-to link is unchanged; that sample was intentionally skipped in the migration).
- **Container samples** (`includes/java-container-samples.md`): links updated to `containerregistry/`, `containerservice/`, and `appservice/`. Renamed **Manage Azure Container Service** to **Manage Azure Kubernetes Service** since ACS is retired in favor of AKS.
- **Web app samples** (`web-apps-samples.md`): 5 links updated to `appservice/samples/`; removed the *Create a web app and deploy from FTP or GitHub* row, which had no migrated sample and was skipped in the migration.

All referenced sample files were verified to exist on `main` of `Azure/azure-sdk-for-java`.